### PR TITLE
Fix several deployment issues

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
   cache_directories:
     - "~/docker"
   pre:
-    - curl -L https://github.com/docker/compose/releases/download/1.10.0/docker-compose-`uname -s`-`uname -m` > /home/ubuntu/bin/docker-compose
+    - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > /home/ubuntu/bin/docker-compose
     - chmod +x /home/ubuntu/bin/docker-compose
   override:
     - sed -i -E "s/#TEST#//g" Dockerfile
@@ -30,6 +30,7 @@ test:
     - mkdir -p reports/rspec
     - export CI=true
     - export CIRCLECI=true
+    - export OS_SERVER_NUMBER_OF_WORKERS=4
   override:
     - docker-compose -f docker-compose.test.yml run web > reports/rspec/rpec_results.html
     - docker-compose stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,79 +1,60 @@
-version: '3'
+# Docker Compose creates multiple containers on a single machine.
+# run `docker-compose up` to create and run/link the containers
+version: '2'
 services:
   db:
-    image: 127.0.0.1:5000/mongo
+    image: mongo:latest
     ports:
       - "27017:27017"
-    deploy:
-      placement:
-        constraints:
-          - node.role == manager
-      resources:
-        reservations:
-          cpus: "1"
   web:
-    image: 127.0.0.1:5000/openstudio-server
+    build:
+      context: .
+      args:
+        rails_env: docker
+    image: nrel/openstudio-server:latest
+    environment:
+      - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
+    links:
+      - db
+      - rserve
     ports:
       - "8080:80"
-      - "443:443"
+    volumes:
+      - osdata:/mnt/openstudio
+  web-background:
+    build:
+      context: .
+      args:
+        rails_env: docker
+    image: nrel/openstudio-server:latest
+    environment:
+      - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
+    links:
+      - db
+      - rserve
+    volumes:
+      - osdata:/mnt/openstudio
+    command: bin/delayed_job -i server --queues=analyses,background run
+  worker:
+    build:
+      context: .
+      args:
+        rails_env: docker
+    image: nrel/openstudio-server:latest
+    environment:
+      - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
+    links:
+      - web
+      - db
+      - rserve
+    command: bin/delayed_job -i worker --queue=simulations run
+  rserve:
+    build: ./docker/R
+    image: nrel/openstudio-rserve:latest
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
     volumes:
       - osdata:/mnt/openstudio
-    depends_on:
-      - db
-    deploy:
-      placement:
-        constraints:
-          - node.role == manager
-      resources:
-        reservations:
-          cpus: "1"
-  web-background:
-    image: 127.0.0.1:5000/openstudio-server
-    volumes:
-      - osdata:/mnt/openstudio
-    command: bin/delayed_job -i server --queues=analyses,background run
-    depends_on:
-      - db
-      - web
-    deploy:
-      placement:
-        constraints:
-          - node.role == manager
-      resources:
-        reservations:
-          cpus: "1"
-  worker:
-    image: 127.0.0.1:5000/openstudio-server
-    command: bin/delayed_job -i worker --queue=simulations run
-    depends_on:
-      - web
-      - web-background
-      - db
-      - rserve
-    deploy:
-      resources:
-        reservations:
-          cpus: "0.99"
-  rserve:
-    image: 127.0.0.1:5000/openstudio-rserve
-    volumes:
-      - osdata:/mnt/openstudio
-    depends_on:
-      - web
-      - web-background
-      - db
-    deploy:
-      placement:
-        constraints:
-          - node.role == manager
-      resources:
-        reservations:
-          cpus: "1"
 volumes:
   osdata:
     external: true
-networks:
-  default:
-    driver: overlay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,61 +1,79 @@
-# Docker Compose creates multiple containers on a single machine.
-# run `docker-compose up` to create and run/link the containers
-version: '2'
+version: '3'
 services:
   db:
-    image: mongo:latest
+    image: 127.0.0.1:5000/mongo
     ports:
       - "27017:27017"
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        reservations:
+          cpus: "1"
   web:
-    build:
-      context: .
-      args:
-        rails_env: docker
-    image: nrel/openstudio-server:latest
-    environment:
-      - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
-    links:
-      - db
-      - rserve
+    image: 127.0.0.1:5000/openstudio-server
     ports:
       - "8080:80"
-    volumes:
-      - osdata:/mnt/openstudio
-  web-background:
-    build:
-      context: .
-      args:
-        rails_env: docker
-    image: nrel/openstudio-server:latest
+      - "443:443"
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
-    links:
+    volumes:
+      - osdata:/mnt/openstudio
+    depends_on:
       - db
-      - rserve
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        reservations:
+          cpus: "1"
+  web-background:
+    image: 127.0.0.1:5000/openstudio-server
     volumes:
       - osdata:/mnt/openstudio
     command: bin/delayed_job -i server --queues=analyses,background run
-  worker:
-    build:
-      context: .
-      args:
-        rails_env: docker
-    image: nrel/openstudio-server:latest
-    environment:
-      - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
-    links:
+    depends_on:
+      - db
       - web
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        reservations:
+          cpus: "1"
+  worker:
+    image: 127.0.0.1:5000/openstudio-server
+    command: bin/delayed_job -i worker --queue=simulations run
+    depends_on:
+      - web
+      - web-background
       - db
       - rserve
-    command: bin/delayed_job -i worker --queue=simulations run
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.99"
   rserve:
-    build: ./docker/R
-    image: nrel/openstudio-rserve:latest
-    environment:
-      - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
+    image: 127.0.0.1:5000/openstudio-rserve
     volumes:
       - osdata:/mnt/openstudio
+    depends_on:
+      - web
+      - web-background
+      - db
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        reservations:
+          cpus: "1"
 volumes:
   osdata:
     external: true
-
+networks:
+  default:
+    driver: overlay

--- a/docker/deployment/docker-compose.aws.yml
+++ b/docker/deployment/docker-compose.aws.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: mongo:latest
+    image: localhost:5000/mongo
     ports:
       - "27017:27017"
     deploy:
@@ -12,7 +12,7 @@ services:
         reservations:
           cpus: "1"
   web:
-    image: nrel/openstudio-server:latest
+    image: localhost:5000/openstudio-server
     ports:
       - "8080:80"
       - "443:443"
@@ -30,7 +30,7 @@ services:
         reservations:
           cpus: "1"
   web-background:
-    image: nrel/openstudio-server:latest
+    image: localhost:5000/openstudio-server
     volumes:
       - osdata:/mnt/openstudio
     command: bin/delayed_job -i server --queues=analyses,background run
@@ -45,7 +45,7 @@ services:
         reservations:
           cpus: "1"
   worker:
-    image: nrel/openstudio-server:latest
+    image: localhost:5000/openstudio-server
     command: bin/delayed_job -i worker --queue=simulations run
     depends_on:
       - web
@@ -57,7 +57,7 @@ services:
         reservations:
           cpus: "0.99"
   rserve:
-    image: nrel/openstudio-rserve:latest
+    image: localhost:5000/openstudio-rserve
     volumes:
       - osdata:/mnt/openstudio
     depends_on:

--- a/docker/deployment/scripts/aws_system_init.sh
+++ b/docker/deployment/scripts/aws_system_init.sh
@@ -10,7 +10,7 @@ sudo apt-get -qq update
 sudo rm -f /boot/grub/menu.lst # https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1485685
 sudo apt-get -y -qq upgrade
 sudo apt-get -y -qq install curl linux-image-extra-$(uname -r) linux-image-extra-virtual htop iftop unzip lvm2 thin-provisioning-tools
-sudo apt-get -y -qq install gdisk kpartx parted
+sudo apt-get -y -qq install gdisk kpartx parted ca-certificates software-properties-common apt-transport-https
 sudo apt -qq -y install python3
 sudo apt -qq -y install ruby
 sudo perl -p -i -e 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"/g'  /etc/default/grub
@@ -49,22 +49,21 @@ echo "Adding the docker GPG to apt-get"
 echo "------------------------------------------------------------------------"
 echo ""
 sleep 1
-curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add -
-apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
-sudo add-apt-repository "deb https://apt.dockerproject.org/repo/ ubuntu-$(lsb_release -cs) main"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get -qq update
 sleep 1
 
 echo ""
 echo "------------------------------------------------------------------------"
-echo "Installing docker-engine version $DOCKER_MACHINE_VERSION~ubuntu-yakkety"
+echo "Installing docker server version $DOCKER_MACHINE_VERSION"
 echo "------------------------------------------------------------------------"
 echo ""
 sleep 1
 echo "" >> /home/ubuntu/.bashrc
 echo "# Configuration variables used to build the OpenStudio Server base image"
 echo "export DOCKER_MACHINE_VERSION=$DOCKER_MACHINE_VERSION" >> /home/ubuntu/.bashrc
-sudo apt-get -y -qq install docker-engine=1.13.0-0~ubuntu-yakkety
+sudo apt-get -y -qq install docker-ce=$DOCKER_MACHINE_VERSION~ce-0~ubuntu-yakkety
 sleep 1
 
 echo ""
@@ -82,18 +81,6 @@ echo -en "[Service]\nExecStart=\nExecStart=/usr/bin/dockerd $DOCKERD_OPTIONS" | 
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 sleep 1
-
-echo ""
-echo "------------------------------------------------------------------------"
-echo "Installing docker-compose version $DOCKER_COMPOSE_VERSION"
-echo "------------------------------------------------------------------------"
-echo ""
-sleep 1
-echo "export DOCKER_COMPOSE_VERSION=$DOCKER_COMPOSE_VERSION" >> /home/ubuntu/.bashrc
-sudo curl -L "https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
-sleep 1
-
 
 echo ""
 echo "------------------------------------------------------------------------"

--- a/docker/deployment/user_variables.json.template
+++ b/docker/deployment/user_variables.json.template
@@ -1,6 +1,5 @@
 {
   "version": "2.0.0-rc0",
-  "docker_machine_version": "1.13.0",
-  "docker_compose_version": "1.10.0",
+  "docker_machine_version": "17.03.0",
   "generated_by": "Your Name Here"
 }


### PR DESCRIPTION
Updated to docker 17.03.0 from 13.0.0.
Changed the deployment protocols to have a private registry which local images are pushed to on boot. This ensures that the swarm doesn't try to resolve image tags against dockerhub.
Fixed issue where only 80 or 8080 resolved the server console. 443 appears to still be an open issue, although it appears to be on the rails configuration side.