### PR TITLE
Fix for 8 GB server zipfile storage limit

### DIFF
--- a/docker/deployment/openstudio_server_docker_base.json
+++ b/docker/deployment/openstudio_server_docker_base.json
@@ -11,7 +11,7 @@
       "access_key": "{{ user `aws_access_key` }}",
       "secret_key": "{{ user `aws_secret_key` }}",
       "region": "us-east-1",
-      "ami_name": "OpenStudio-Server-Docker-{{ user `version` }}",
+      "ami_name": "OpenStudio-Server-Docker-{{ user `version` }}{{ user `ami_version_extension` }}",
       "ami_description": "This AMI serves as the base image used for deploying the OpenStudio Server on AWS using Docker. The base OpenStudio Server image from DockerHub on this AMI is {{ user `openstudio_server_base_version` }}.",
       "instance_type": "c3.large",
       "ssh_username": "ubuntu",
@@ -25,7 +25,7 @@
         {
           "device_name": "/dev/sdn",
           "volume_type": "gp2",
-          "volume_size": 20,
+          "volume_size": 200,
           "delete_on_termination": true
         }
       ],
@@ -37,33 +37,9 @@
           "delete_on_termination": true
         },
         {
-          "device_name": "/dev/sdb",
-          "virtual_name": "ephemeral0"
-        },
-        {
-          "device_name": "/dev/sdc",
-          "virtual_name": "ephemeral1"
-        },
-        {
-          "device_name": "/dev/sdd",
-          "virtual_name": "ephemeral2"
-        },
-        {
-          "device_name": "/dev/sde",
-          "virtual_name": "ephemeral3"
-        },
-        {
-          "device_name": "/dev/sdf",
-          "virtual_name": "ephemeral4"
-        },
-        {
-          "device_name": "/dev/sdg",
-          "virtual_name": "ephemeral5"
-        },
-        {
           "device_name": "/dev/sdn",
           "volume_type": "gp2",
-          "volume_size": 20,
+          "volume_size": 200,
           "delete_on_termination": true
         }
       ],

--- a/docker/deployment/scripts/aws_system_init.sh
+++ b/docker/deployment/scripts/aws_system_init.sh
@@ -30,9 +30,15 @@ else
 	sudo pvcreate /dev/sdn
 	sudo vgcreate docker /dev/sdn
 fi
-sudo lvcreate --wipesignatures y -n thinpool docker -l 95%VG
+sudo lvcreate --wipesignatures y -n graph docker -l 5%VG
+sudo lvcreate --wipesignatures y -n thinpool docker -l 90%VG
 sudo lvcreate --wipesignatures y -n thinpoolmeta docker -l 1%VG
 sudo lvconvert -y --zero n -c 512K --thinpool docker/thinpool --poolmetadata docker/thinpoolmeta
+sudo mkdir /var/lib/docker
+sudo chmod 722 /var/lib/docker
+sudo mkfs.ext4 /dev/docker/graph
+echo '/dev/mapper/docker-graph /var/lib/docker ext4 defaults 0 2' | sudo tee -a /etc/fstab
+sudo mount -a
 sudo mkdir -p /etc/lvm/profile/
 echo -e "activation {\nthin_pool_autoextend_threshold=80\nthin_pool_autoextend_percent=20\n}" | sudo tee /etc/lvm/profile/docker-thinpool.profile
 sudo lvchange --metadataprofile docker-thinpool docker/thinpool

--- a/docker/deployment/scripts/aws_system_init.sh
+++ b/docker/deployment/scripts/aws_system_init.sh
@@ -30,8 +30,8 @@ else
 	sudo pvcreate /dev/sdn
 	sudo vgcreate docker /dev/sdn
 fi
-sudo lvcreate --wipesignatures y -n graph docker -l 5%VG
-sudo lvcreate --wipesignatures y -n thinpool docker -l 90%VG
+sudo lvcreate --wipesignatures y -n graph docker -l 1%VG
+sudo lvcreate --wipesignatures y -n thinpool docker -l 5%VG
 sudo lvcreate --wipesignatures y -n thinpoolmeta docker -l 1%VG
 sudo lvconvert -y --zero n -c 512K --thinpool docker/thinpool --poolmetadata docker/thinpoolmeta
 sudo mkdir /var/lib/docker

--- a/docker/deployment/scripts/server_provision.sh
+++ b/docker/deployment/scripts/server_provision.sh
@@ -26,7 +26,9 @@ else
 	sudo vgextend docker -y /dev/sdf
 	sudo vgextend docker -y /dev/sdg
 fi
-sudo lvextend -l+100%FREE -n docker/thinpool
+sudo lvextend -l+25%FREE -n docker/thinpool
+sudo lvextend -l+75%FREE -n docker/graph
+sudo resize2fs /dev/docker/graph
 new_sectors="$(($(sudo blockdev --getsize64 /dev/docker/thinpool)/512))"
 echo "New 512 sector count for 'docker-thinpool' is $new_sectors"
 new_table=${docker_thinpool_table/${old_sectors}/${new_sectors}}

--- a/docker/deployment/user_variables.json.template
+++ b/docker/deployment/user_variables.json.template
@@ -1,5 +1,6 @@
 {
-  "version": "2.0.0-rc0",
+  "version": "2.1.0",
+  "ami_version_extension": "",
   "docker_machine_version": "17.03.0",
   "generated_by": "Your Name Here"
 }


### PR DESCRIPTION
75% of the storage attached to the server node, plus ~130 GB of EBS, will be available to the osdata volume, which stores all server assets, including zipped results and reports for each datapoint. See https://github.com/NREL/OpenStudio/issues/2605