### PR TITLE
Patch 0 for 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN mkdir /var/log/nginx
 ADD /docker/server/nginx.conf /opt/nginx/conf/nginx.conf
 
 # Run this separate to cache the download
-ENV OPENSTUDIO_VERSION 2.2.2
-ENV OPENSTUDIO_SHA ebdeaa44f8
+ENV OPENSTUDIO_VERSION 2.3.0
+ENV OPENSTUDIO_SHA 597aeef208
 
 # Download from S3
 ENV OPENSTUDIO_DOWNLOAD_BASE_URL https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN mkdir /var/log/nginx
 ADD /docker/server/nginx.conf /opt/nginx/conf/nginx.conf
 
 # Run this separate to cache the download
-ENV OPENSTUDIO_VERSION 2.2.1
-ENV OPENSTUDIO_SHA 92a7ed37f1
+ENV OPENSTUDIO_VERSION 2.2.2
+ENV OPENSTUDIO_SHA ebdeaa44f8
 
 # Download from S3
 ENV OPENSTUDIO_DOWNLOAD_BASE_URL https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,8 +112,8 @@ RUN mkdir /var/log/nginx
 ADD /docker/server/nginx.conf /opt/nginx/conf/nginx.conf
 
 # Run this separate to cache the download
-ENV OPENSTUDIO_VERSION 2.2.2
-ENV OPENSTUDIO_SHA ebdeaa44f8
+ENV OPENSTUDIO_VERSION 2.2.1
+ENV OPENSTUDIO_SHA 92a7ed37f1
 
 # Download from S3
 ENV OPENSTUDIO_DOWNLOAD_BASE_URL https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ ADD /docker/server/nginx.conf /opt/nginx/conf/nginx.conf
 
 # Run this separate to cache the download
 ENV OPENSTUDIO_VERSION 2.3.0
-ENV OPENSTUDIO_SHA 597aeef208
+ENV OPENSTUDIO_SHA cf58ee1e38
 
 # Download from S3
 ENV OPENSTUDIO_DOWNLOAD_BASE_URL https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,6 +190,10 @@ ADD .rubocop.yml /opt/openstudio/.rubocop.yml
 RUN rm Gemfile.lock
 RUN bundle install
 
+# Configure IPVS keepalive
+ADD /docker/server/ipvs-keepalive.conf /etc/sysctl.d/ipvs-keepalive.conf
+RUN sudo sysctl --system
+
 # forward request and error logs to docker log collector
 # TODO: How to get logs out of this, mount shared volume?
 #RUN ln -sf /dev/stdout /var/log/nginx/access.log

--- a/ci/travis/setup.sh
+++ b/ci/travis/setup.sh
@@ -3,6 +3,7 @@ set -ev
 if [ "${REDHAT_BUILD}" = 'false' ]; then
 	if [ "${OSX_BUILD}" = 'true' ]; then
 		echo 'IN AN OSX BUILD'
+		brew update
 		brew install mongo
 		unset BUNDLE_GEMFILE
 		curl -SLO https://openstudio-resources.s3.amazonaws.com/pat-dependencies/OpenStudio-2.0.3.40f61c64a3-darwin.zip

--- a/docker/R/Dockerfile
+++ b/docker/R/Dockerfile
@@ -90,9 +90,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 #### Build R and install R packages.
-ENV R_VERSION 3.2.3
+ENV R_VERSION 3.4.1
 ENV R_MAJOR_VERSION 3
-ENV R_SHA b93b7d878138279234160f007cb9b7f81b8a72c012a15566e9ec5395cfd9b6c1
+ENV R_SHA 02b1135d15ea969a3582caeb95594a05e830a6debcdb5b85ed2d5836a6a3fc78
 RUN curl -fSL -o R.tar.gz "http://cran.fhcrc.org/src/base/R-$R_MAJOR_VERSION/R-$R_VERSION.tar.gz" \
     && echo "$R_SHA R.tar.gz" | sha256sum -c - \
     && mkdir /usr/src/R \

--- a/docker/R/Dockerfile
+++ b/docker/R/Dockerfile
@@ -124,6 +124,10 @@ ADD /start.R /start.R
 ADD /Rserv.conf /etc/Rserv.conf
 RUN mkdir -p /mnt/openstudio/log && chmod 775 /mnt/openstudio/log
 
+# Configure keepalive for IPVS
+ADD /ipvs-keepalive.conf /etc/sysctl.d/ipvs-keepalive.conf
+RUN sudo sysctl --system
+
 ADD /rserve-entrypoint.sh /usr/local/bin/rserve-entrypoint
 RUN chmod 755 /usr/local/bin/rserve-entrypoint
 ENTRYPOINT ["rserve-entrypoint"]

--- a/docker/R/Rserv.conf
+++ b/docker/R/Rserv.conf
@@ -1,4 +1,5 @@
 remote enable
+keep.alive enable
 auth disable
 fileio enable
 maxinbuf 500000

--- a/docker/R/install_packages.R
+++ b/docker/R/install_packages.R
@@ -20,4 +20,4 @@ install.packages('Rcpp', repos=c('http://cloud.r-project.org','http://cran.r-pro
 install.packages('plyr', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
 install.packages('ggplot2', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
 install.packages('sensitivity', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('Rserve', configure.args=c('PKG_CPPFLAGS=-DNODAEMON'), repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
+install.packages('Rserve', configure.args=c('PKG_CPPFLAGS=-DNODAEMON'), repos=c('http://rforge.net'))

--- a/docker/R/ipvs-keepalive.conf
+++ b/docker/R/ipvs-keepalive.conf
@@ -1,0 +1,5 @@
+# This file serves to allow TCP connections to be persisted over 900 seconds
+# allowing proper execution of long running RServe SNOW cluster EOF returns
+net.ipv4.tcp_keepalive_time = 600
+net.ipv4.tcp_keepalive_intvl = 60
+net.ipv4.tcp_keepalive_probes = 5

--- a/docker/R/rserve-entrypoint.sh
+++ b/docker/R/rserve-entrypoint.sh
@@ -2,7 +2,7 @@
 
 echo 'Provisioning data volume osdata'
 mkdir -p /mnt/openstudio/log && chmod 775 /mnt/openstudio/log
-mkdir -p /tmp/coredumps/ && chmod 777 /tmp/coredumps/
+mkdir -p /mnt/coredumps/ && chmod 777 /mnt/coredumps/
 echo 'Beginning CMD boot process.'
 
 exec "$@"

--- a/docker/deployment/scripts/aws_system_init.sh
+++ b/docker/deployment/scripts/aws_system_init.sh
@@ -77,7 +77,7 @@ sudo systemctl enable docker
 sudo groupadd docker
 sudo usermod -aG docker ubuntu
 sudo mkdir /etc/systemd/system/docker.service.d
-echo -en "[Service]\nExecStart=\nExecStart=/usr/bin/dockerd $DOCKERD_OPTIONS" | sudo tee -a "/etc/systemd/system/docker.service.d/config.conf"
+echo -en "[Service]\nExecStart=\nExecStart=/usr/bin/dockerd $DOCKERD_OPTIONS\n" | sudo tee -a /etc/systemd/system/docker.service.d/config.conf
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 sleep 1
@@ -95,6 +95,17 @@ ec2_tools_folder=$(ls /usr/local/ec2)
 echo "export EC2_AMITOOL_HOME=/usr/local/ec2/$ec2_tools_folder" >> /home/ubuntu/.bashrc
 echo 'export PATH="$EC2_AMITOOL_HOME/bin:$PATH"' >> /home/ubuntu/.bashrc
 sudo ln -s /usr/local/ec2/${ec2_tools_folder}/bin/* /bin
+sleep 1
+
+echo ""
+echo "------------------------------------------------------------------------"
+echo "Setting IPVS keepalive configuration"
+echo "------------------------------------------------------------------------"
+echo ""
+sleep 1
+echo -en "net.ipv4.tcp_keepalive_time = 600\nnet.ipv4.tcp_keepalive_intvl = 60\nnet.ipv4.tcp_keepalive_probes = 5\n" | sudo tee /etc/sysctl.d/ipvs-keepalive.conf
+sudo chmod 644 /etc/sysctl.d/ipvs-keepalive.conf
+sudo sysctl --system
 sleep 1
 
 echo ""

--- a/docker/server/ipvs-keepalive.conf
+++ b/docker/server/ipvs-keepalive.conf
@@ -1,0 +1,5 @@
+# This file serves to allow TCP connections to be persisted over 900 seconds
+# allowing proper execution of long running RServe SNOW cluster EOF returns
+net.ipv4.tcp_keepalive_time = 600
+net.ipv4.tcp_keepalive_intvl = 60
+net.ipv4.tcp_keepalive_probes = 5

--- a/docker/server/rails-entrypoint.sh
+++ b/docker/server/rails-entrypoint.sh
@@ -6,7 +6,7 @@ mkdir -p /mnt/openstudio/server/R && chmod 777 /mnt/openstudio/server/R
 mkdir -p /mnt/openstudio/server/assets && chmod 777 /mnt/openstudio/server/assets
 mkdir -p /mnt/openstudio/server/assets/variables && chmod 777 /mnt/openstudio/server/assets/variables
 mkdir -p /opt/openstudio/server/tmp && chmod 777 /opt/openstudio/server/tmp
-mkdir -p /tmp/coredumps/ && chmod 777 /tmp/coredumps/
+mkdir -p /mnt/coredumps/ && chmod 777 /mnt/coredumps/
 sleep 1
 
 echo 'Defaulting required variables which are not present'

--- a/server/lib/analysis_library/nsga_nrel.rb
+++ b/server/lib/analysis_library/nsga_nrel.rb
@@ -251,13 +251,13 @@ class AnalysisLibrary::NsgaNrel < AnalysisLibrary::Base
             source(paste(r_scripts_path,'/nsga.R',sep=''))
           }
         end
-
+        logger.info 'Returned from rserve nsga_nrel block'
         # TODO: find any results of the algorithm and save to the analysis
       else
         raise 'could not start the cluster (most likely timed out)'
       end
 
-    rescue => e
+    rescue StandardError, ScriptError, NoMemoryError => e
       log_message = "#{__FILE__} failed with #{e.message}, #{e.backtrace.join("\n")}"
       logger.error log_message
       @analysis.status_message = log_message
@@ -268,7 +268,13 @@ class AnalysisLibrary::NsgaNrel < AnalysisLibrary::Base
       @analysis.save!
     ensure
       # ensure that the cluster is stopped
-      cluster.stop if cluster
+      logger.info 'Executing rgenound.rb ensure block'
+      begin
+        cluster.stop if cluster
+      rescue StandardError, ScriptError, NoMemoryError => e
+        logger.error "Error executing cluster.stop, #{e.message}, #{e.backtrace}"
+      end
+      logger.info 'Successfully executed cluster.stop'
 
       # Post process the results and jam into the database
       best_result_json = "#{APP_CONFIG['sim_root_path']}/analysis_#{@analysis.id}/best_result.json"

--- a/server/lib/analysis_library/optim.rb
+++ b/server/lib/analysis_library/optim.rb
@@ -239,11 +239,12 @@ class AnalysisLibrary::Optim < AnalysisLibrary::Base
             source(paste(r_scripts_path,'/optim.R',sep=''))
             }
         end
+        logger.info 'Returned from rserve optim block'
       else
         raise 'could not start the cluster (most likely timed out)'
       end
 
-    rescue => e
+    rescue StandardError, ScriptError, NoMemoryError => e
       log_message = "#{__FILE__} failed with #{e.message}, #{e.backtrace.join("\n")}"
       logger.error log_message
       @analysis.status_message = log_message
@@ -254,7 +255,13 @@ class AnalysisLibrary::Optim < AnalysisLibrary::Base
       @analysis.save!
     ensure
       # ensure that the cluster is stopped
-      cluster.stop if cluster
+      logger.info 'Executing rgenound.rb ensure block'
+      begin
+        cluster.stop if cluster
+      rescue StandardError, ScriptError, NoMemoryError => e
+        logger.error "Error executing cluster.stop, #{e.message}, #{e.backtrace}"
+      end
+      logger.info 'Successfully executed cluster.stop'
 
       # Post process the results and jam into the database
       best_result_json = "#{APP_CONFIG['sim_root_path']}/analysis_#{@analysis.id}/best_result.json"

--- a/server/lib/analysis_library/pso.rb
+++ b/server/lib/analysis_library/pso.rb
@@ -266,13 +266,13 @@ class AnalysisLibrary::Pso < AnalysisLibrary::Base
             source(paste(r_scripts_path,'/pso.R',sep=''))
           }
         end
-
+        logger.info 'Returned from rserve pso block'
         # TODO: find any results of the algorithm and save to the analysis
       else
         raise 'could not start the cluster (most likely timed out)'
       end
 
-    rescue => e
+    rescue StandardError, ScriptError, NoMemoryError => e
       log_message = "#{__FILE__} failed with #{e.message}, #{e.backtrace.join("\n")}"
       logger.error log_message
       @analysis.status_message = log_message
@@ -283,7 +283,13 @@ class AnalysisLibrary::Pso < AnalysisLibrary::Base
       @analysis.save!
     ensure
       # ensure that the cluster is stopped
-      cluster.stop if cluster
+      logger.info 'Executing rgenound.rb ensure block'
+      begin
+        cluster.stop if cluster
+      rescue StandardError, ScriptError, NoMemoryError => e
+        logger.error "Error executing cluster.stop, #{e.message}, #{e.backtrace}"
+      end
+      logger.info 'Successfully executed cluster.stop'
 
       # Post process the results and jam into the database
       best_result_json = "#{APP_CONFIG['sim_root_path']}/analysis_#{@analysis.id}/best_result.json"

--- a/server/lib/analysis_library/sobol.rb
+++ b/server/lib/analysis_library/sobol.rb
@@ -230,13 +230,13 @@ class AnalysisLibrary::Sobol < AnalysisLibrary::Base
             source(paste(r_scripts_path,'/sobol.R',sep=''))
           }
         end
-
+        logger.info 'Returned from rserve sobol block'
         # TODO: find any results of the algorithm and save to the analysis
       else
         raise 'could not start the cluster (most likely timed out)'
       end
 
-    rescue => e
+    rescue StandardError, ScriptError, NoMemoryError => e
       log_message = "#{__FILE__} failed with #{e.message}, #{e.backtrace.join("\n")}"
       logger.error log_message
       @analysis.status_message = log_message
@@ -247,7 +247,13 @@ class AnalysisLibrary::Sobol < AnalysisLibrary::Base
       @analysis.save!
     ensure
       # ensure that the cluster is stopped
-      cluster.stop if cluster
+      logger.info 'Executing rgenound.rb ensure block'
+      begin
+        cluster.stop if cluster
+      rescue StandardError, ScriptError, NoMemoryError => e
+        logger.error "Error executing cluster.stop, #{e.message}, #{e.backtrace}"
+      end
+      logger.info 'Successfully executed cluster.stop'
 
       # Post process the results and jam into the database
       best_result_json = "#{APP_CONFIG['sim_root_path']}/analysis_#{@analysis.id}/best_result.json"

--- a/server/lib/analysis_library/spea_nrel.rb
+++ b/server/lib/analysis_library/spea_nrel.rb
@@ -251,13 +251,13 @@ class AnalysisLibrary::SpeaNrel < AnalysisLibrary::Base
               source(paste(r_scripts_path,'/spea.R',sep=''))
            }
         end
-
+        logger.info 'Returned from rserve spea_nrel block'
         # TODO: find any results of the algorithm and save to the analysis
       else
         raise 'could not start the cluster (most likely timed out)'
       end
 
-    rescue => e
+    rescue StandardError, ScriptError, NoMemoryError => e
       log_message = "#{__FILE__} failed with #{e.message}, #{e.backtrace.join("\n")}"
       logger.error log_message
       @analysis.status_message = log_message
@@ -268,7 +268,13 @@ class AnalysisLibrary::SpeaNrel < AnalysisLibrary::Base
       @analysis.save!
     ensure
       # ensure that the cluster is stopped
-      cluster.stop if cluster
+      logger.info 'Executing rgenound.rb ensure block'
+      begin
+        cluster.stop if cluster
+      rescue StandardError, ScriptError, NoMemoryError => e
+        logger.error "Error executing cluster.stop, #{e.message}, #{e.backtrace}"
+      end
+      logger.info 'Successfully executed cluster.stop'
 
       # Post process the results and jam into the database
       best_result_json = "#{APP_CONFIG['sim_root_path']}/analysis_#{@analysis.id}/best_result.json"

--- a/server/lib/openstudio_server/version.rb
+++ b/server/lib/openstudio_server/version.rb
@@ -34,6 +34,6 @@
 # *******************************************************************************
 
 module OpenstudioServer
-  VERSION = '2.2.1'.freeze
+  VERSION = '2.2.2'.freeze
   VERSION_EXT = ''.freeze # with preceding - or +
 end

--- a/server/lib/openstudio_server/version.rb
+++ b/server/lib/openstudio_server/version.rb
@@ -34,6 +34,6 @@
 # *******************************************************************************
 
 module OpenstudioServer
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.2.1'.freeze
   VERSION_EXT = ''.freeze # with preceding - or +
 end

--- a/server/lib/openstudio_server/version.rb
+++ b/server/lib/openstudio_server/version.rb
@@ -35,5 +35,5 @@
 
 module OpenstudioServer
   VERSION = '2.3.0'.freeze
-  VERSION_EXT = '-rc0'.freeze # with preceding - or +
+  VERSION_EXT = ''.freeze # with preceding - or +
 end

--- a/server/lib/openstudio_server/version.rb
+++ b/server/lib/openstudio_server/version.rb
@@ -35,5 +35,5 @@
 
 module OpenstudioServer
   VERSION = '2.3.0'.freeze
-  VERSION_EXT = ''.freeze # with preceding - or +
+  VERSION_EXT = '-p0'.freeze # with preceding - or +
 end

--- a/server/lib/openstudio_server/version.rb
+++ b/server/lib/openstudio_server/version.rb
@@ -34,6 +34,6 @@
 # *******************************************************************************
 
 module OpenstudioServer
-  VERSION = '2.2.2'.freeze
-  VERSION_EXT = ''.freeze # with preceding - or +
+  VERSION = '2.3.0'.freeze
+  VERSION_EXT = '-rc0'.freeze # with preceding - or +
 end


### PR DESCRIPTION
This patch:
* updates to R from 3.2.3 to 3.4.1
* fixes a networking issue in deployment that caused optimization analyses running longer than 15 minutes to never finish
* adds logging of segmentation faults in the `/mnt/coredumps/` directory
* more aggressively rescues errors in long running analyses