### PR TITLE
Fixing an ipam subnet CIDR /24 that limited network to 252 containers

### DIFF
--- a/docker/deployment/docker-compose.aws.yml
+++ b/docker/deployment/docker-compose.aws.yml
@@ -88,3 +88,7 @@ volumes:
 networks:
   default:
     driver: overlay
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16


### PR DESCRIPTION
https://github.com/moby/moby/issues/26702