### PR TITLE
Rails-memory fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,8 +207,8 @@ ADD /docker/server/memfix-controller.rb /usr/local/lib/memfix-controller.rb
 ADD /docker/server/memfix.rb /usr/local/lib/memfix.rb
 RUN chmod +x /usr/local/bin/start-server
 RUN chmod +x /usr/local/bin/run-server-tests
-RUN chmod +x /usr/local/bin/memfix-controler.rb
-RUN chmod +x /usr/local/bin/memfix.rb
+RUN chmod +x /usr/local/lib/memfix-controller.rb
+RUN chmod +x /usr/local/lib/memfix.rb
 
 # set the permissions for windows users
 RUN chmod +x /opt/openstudio/server/bin/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,8 +203,8 @@ RUN chmod 666 /opt/openstudio/server/log/*.log
 
 ADD /docker/server/start-server.sh /usr/local/bin/start-server
 ADD /docker/server/run-server-tests.sh /usr/local/bin/run-server-tests
-ADD /docker/server/memfix-controler.rb /usr/local/bin/memfix-controler.rb
-ADD /docker/server/memfix.rb /usr/local/bin/memfix.rb
+ADD /docker/server/memfix-controller.rb /usr/local/lib/memfix-controller.rb
+ADD /docker/server/memfix.rb /usr/local/lib/memfix.rb
 RUN chmod +x /usr/local/bin/start-server
 RUN chmod +x /usr/local/bin/run-server-tests
 RUN chmod +x /usr/local/bin/memfix-controler.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,8 +203,12 @@ RUN chmod 666 /opt/openstudio/server/log/*.log
 
 ADD /docker/server/start-server.sh /usr/local/bin/start-server
 ADD /docker/server/run-server-tests.sh /usr/local/bin/run-server-tests
+ADD /docker/server/memfix-controler.rb /usr/local/bin/memfix-controler.rb
+ADD /docker/server/memfix.rb /usr/local/bin/memfix.rb
 RUN chmod +x /usr/local/bin/start-server
 RUN chmod +x /usr/local/bin/run-server-tests
+RUN chmod +x /usr/local/bin/memfix-controler.rb
+RUN chmod +x /usr/local/bin/memfix.rb
 
 # set the permissions for windows users
 RUN chmod +x /opt/openstudio/server/bin/*

--- a/docker/server/memfix-controller.rb
+++ b/docker/server/memfix-controller.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
 require 'daemons'
-Daemons.run('memfixer.rb')
+Daemons.run('/usr/local/lib/memfix.rb')
 

--- a/docker/server/memfix-controller.rb
+++ b/docker/server/memfix-controller.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'daemons'
+Daemons.run('memfixer.rb')
+

--- a/docker/server/memfix.rb
+++ b/docker/server/memfix.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+cmd_str = 'while [ "0" -eq "0" ]; do for pid in $(pidof "Passenger RubyApp: /opt/openstudio/server/public (docker)"); do memory=$(cat /proc/$pid/status | grep VmRSS | grep -o [0-9]*); if [ "$memory" -gt "500000" ]; then echo "Killing pid $pid using $memory kB of memory" >> "/opt/openstudio/server/log/mem_saver.log"; kill $pid; fi; done; sleep 901; done'
+loop do
+  system cmd_str
+end
+

--- a/docker/server/start-server.sh
+++ b/docker/server/start-server.sh
@@ -3,6 +3,6 @@
 # Always create new indexes in case the models have changed
 cd /opt/openstudio/server && bundle exec rake db:mongoid:create_indexes
 
-ruby /usr/local/bin/memfix-controler.rb start
+ruby /usr/local/lib/memfix-controller.rb start
 
 /opt/nginx/sbin/nginx

--- a/docker/server/start-server.sh
+++ b/docker/server/start-server.sh
@@ -3,4 +3,6 @@
 # Always create new indexes in case the models have changed
 cd /opt/openstudio/server && bundle exec rake db:mongoid:create_indexes
 
+ruby /usr/local/bin/memfix-controler.rb start
+
 /opt/nginx/sbin/nginx


### PR DESCRIPTION
Implements a process killer in the web container which destroys passenger app workers holding over 500 MBs of RSS.