### PR TITLE
Fix install_gems requirement of rspec and rubocop.

### DIFF
--- a/server/lib/tasks/rubocop.rake
+++ b/server/lib/tasks/rubocop.rake
@@ -34,7 +34,7 @@
 # *******************************************************************************
 
 namespace :rubocop do
-  if Rails.env != 'production' && Rails.env != 'docker'
+  if Rails.env != 'production' && Rails.env != 'docker' && Rails.env != 'local'
     require 'rubocop/rake_task'
 
     desc 'Run Rubocop on the server directory'


### PR DESCRIPTION
This resolves an issue causing the `--with-test-development` flag to be required for building packages using the `openstudio_meta` command.