### PR TITLE
add wait-for-it to ensure processes start  in the correct order

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -35,6 +35,7 @@ services:
       resources:
         reservations:
           cpus: "1"
+    command: /usr/local/bin/start-server
   web-background:
     image: nrel/openstudio-server:latest
     environment:
@@ -42,7 +43,6 @@ services:
       - QUEUES=background,analyses
     volumes:
       - osdata:/mnt/openstudio
-    command: bundle exec rake environment resque:work
     depends_on:
       - db
       - queue
@@ -54,9 +54,9 @@ services:
       resources:
         reservations:
           cpus: "1"
+    command: /usr/local/bin/start-web-background
   worker:
     image: nrel/openstudio-server:latest
-    command: bundle exec rake environment resque:workers
     environment:
       - QUEUES=simulations
       - COUNT=1
@@ -71,6 +71,7 @@ services:
       resources:
         reservations:
           cpus: "0.99"
+    command: /usr/local/bin/start-workers
   rserve:
     image: nrel/openstudio-rserve:latest
     volumes:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -28,6 +28,7 @@ services:
       - "8080:80"
     volumes:
       - osdata:/mnt/openstudio
+    command: /usr/local/bin/start-server
   web-background:
     image: 127.0.0.1:5000/openstudio-server
     build:
@@ -44,7 +45,7 @@ services:
       - web
     volumes:
       - osdata:/mnt/openstudio
-    command: bundle exec rake environment resque:work
+    command: /usr/local/bin/start-web-background
   worker:
     image: 127.0.0.1:5000/openstudio-server
     build:
@@ -61,7 +62,7 @@ services:
       - db
       - queue
       - rserve
-    command: bundle exec rake environment resque:workers
+    command: /usr/local/bin/start-workers
   rserve:
     image: 127.0.0.1:5000/openstudio-rserve
     build: ./docker/R

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - "8080:80"
     volumes:
       - osdata:/mnt/openstudio
+    command: /usr/local/bin/start-server
   web-background:
     image: nrel/openstudio-server:latest
     build:
@@ -44,7 +45,7 @@ services:
       - web
     volumes:
       - osdata:/mnt/openstudio
-    command: bundle exec rake environment resque:work
+    command: /usr/local/bin/start-web-background
   worker:
     image: nrel/openstudio-server:latest
     build:
@@ -61,7 +62,7 @@ services:
       - db
       - queue
       - rserve
-    command: bundle exec rake environment resque:workers
+    command: /usr/local/bin/start-workers
   rserve:
     image: nrel/openstudio-rserve:latest
     build: ./docker/R

--- a/docker/deployment/docker-compose.aws.yml
+++ b/docker/deployment/docker-compose.aws.yml
@@ -46,6 +46,7 @@ services:
       resources:
         reservations:
           cpus: "AWS_WEB_CORES"
+    command: /usr/local/bin/start-server
   web-background:
     image: localhost:5000/openstudio-server
     environment:
@@ -53,7 +54,6 @@ services:
       - QUEUES=background,analyses
     volumes:
       - osdata:/mnt/openstudio
-    command: bundle exec rake environment resque:work
     depends_on:
       - db
       - web
@@ -65,12 +65,12 @@ services:
       resources:
         reservations:
           cpus: "1"
+    command: /usr/local/bin/start-web-background
   worker:
     image: localhost:5000/openstudio-server
     environment:
       - QUEUES=simulations
       - COUNT=1
-    command: bundle exec rake environment resque:workers
     volumes:
       - /mnt/openstudio
     depends_on:
@@ -83,6 +83,7 @@ services:
       resources:
         reservations:
           cpus: "1"
+    command: /usr/local/bin/start-workers
   rserve:
     image: localhost:5000/openstudio-rserve
     volumes:

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     volumes:
       - osdata:/mnt/openstudio
       - ../..:/opt/openstudio/
+    # TODO: This is not using the wait-for-it script, not sure if we still want this file.
     command: ../server/bin/delayed_job -i server --queues=analyses,background run
   worker:
     build:

--- a/docker/server/rails-entrypoint.sh
+++ b/docker/server/rails-entrypoint.sh
@@ -9,14 +9,17 @@ mkdir -p /opt/openstudio/server/tmp && chmod 777 /opt/openstudio/server/tmp
 mkdir -p /mnt/coredumps/ && chmod 777 /mnt/coredumps/
 sleep 1
 
-echo 'Defaulting required variables which are not present'
+echo 'Setting permissions on logs'
+chmod 775 /opt/openstudio/server/log
+chmod 666 /opt/openstudio/server/log/*.log
 sleep 1
+
+echo 'Defaulting required variables which are not present'
 [ -z "$MAX_REQUESTS" ] && export MAX_REQUESTS=50;
 [ -z "$MAX_POOL" ] && export MAX_POOL=16;
 sleep 1
 
 echo 'Configuring nginx'
-sleep 1
 { rm /opt/nginx/conf/nginx.conf && awk  -v MAX_REQUESTS=$MAX_REQUESTS '{gsub("MAX_REQUESTS_SUB", MAX_REQUESTS, $0); print}' > /opt/nginx/conf/nginx.conf; } < /opt/nginx/conf/nginx.conf
 { rm /opt/nginx/conf/nginx.conf && awk  -v MAX_POOL=$MAX_POOL '{gsub("MAX_POOL_SUB", MAX_POOL, $0); print}' > /opt/nginx/conf/nginx.conf; } < /opt/nginx/conf/nginx.conf
 sleep 1

--- a/docker/server/run-server-tests.sh
+++ b/docker/server/run-server-tests.sh
@@ -11,6 +11,12 @@ do
   sleep 1s
 done
 
+echo "Waiting for Mongo to start"
+/usr/local/bin/wait-for-it --strict db:27017
+
+echo "Waiting for Redis to start"
+/usr/local/bin/wait-for-it --strict queue:6379
+
 # Always create new indexes in case the models have changed
 cd /opt/openstudio/server && bundle exec rspec; (( exit_status = exit_status || $? ))
 cd /opt/openstudio/server && bundle exec rake rubocop:run; (( exit_status = exit_status || $? ))

--- a/docker/server/start-server-dev.sh
+++ b/docker/server/start-server-dev.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+echo "Waiting for Mongo to start"
+/usr/local/bin/wait-for-it --strict db:27017
+
+echo "Waiting for Redis to start"
+/usr/local/bin/wait-for-it --strict queue:6379
+
 # Always create new indexes in case the models have changed
 cd /opt/openstudio/server && bundle exec rake db:mongoid:create_indexes
 

--- a/docker/server/start-server.sh
+++ b/docker/server/start-server.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
+echo "Waiting for Mongo to start"
+/usr/local/bin/wait-for-it --strict db:27017
+
+echo "Waiting for Redis to start"
+/usr/local/bin/wait-for-it --strict queue:6379
+
 # Always create new indexes in case the models have changed
 cd /opt/openstudio/server && bundle exec rake db:mongoid:create_indexes
 
+# The memfix-controller seems to have causes some issues with NRCan, need to revisit.
+# https://github.com/NREL/OpenStudio-server/issues/348
 ruby /usr/local/lib/memfix-controller.rb start
 
 /opt/nginx/sbin/nginx

--- a/docker/server/start-web-background.sh
+++ b/docker/server/start-web-background.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "Waiting for Mongo to start"
+/usr/local/bin/wait-for-it --strict db:27017
+
+echo "Waiting for Redis to start"
+/usr/local/bin/wait-for-it --strict queue:6379
+
+cd /opt/openstudio/server && bundle exec rake environment resque:work

--- a/docker/server/start-workers.sh
+++ b/docker/server/start-workers.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "Waiting for Mongo to start"
+/usr/local/bin/wait-for-it --strict db:27017
+
+echo "Waiting for Redis to start"
+/usr/local/bin/wait-for-it --strict queue:6379
+
+cd /opt/openstudio/server && bundle exec rake environment resque:workers

--- a/docker/server/wait-for-it.sh
+++ b/docker/server/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+# From: https://github.com/vishnubob/wait-for-it
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
The background web containers were starting before mongodb was available. 