### PR TITLE
Allow failed init scripts to return zip files with logs.

### DIFF
--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -211,7 +211,8 @@ module DjJobs
             results = JSON.parse(File.read(results_file), symbolize_names: true)
             @data_point.update(results: results)
           else
-            raise "Could not find results #{results_file}"
+            run_result = :errored
+            @sim_logger.error "Could not find results #{results_file}"
           end
 
           @sim_logger.info 'Saving files/reports back to the server'


### PR DESCRIPTION
Currently, when the WFG instantiation / CLI fails to load, no measure_attributes.json file is written, which causes the raise condition which I've removed. This raise leads to the datapoint directory not being zipped and returned to the user through the UI, making it impossible to access the workflow init script log file (which may be needed for debugging) without ssh'ing into the cluster.