### PR TITLE
remove sudo from install scripts for openstudio and ruby

### DIFF
--- a/ci/travis/setup.sh
+++ b/ci/travis/setup.sh
@@ -33,7 +33,7 @@ else
         sudo apt-get update
         sudo apt-get install -y pv tree
         mkdir -p reports/rspec
-        ./docker/deployment/scripts/install_openstudio.sh $OPENSTUDIO_VERSION $OPENSTUDIO_VERSION_SHA
+        sudo ./docker/deployment/scripts/install_openstudio.sh $OPENSTUDIO_VERSION $OPENSTUDIO_VERSION_SHA
     fi
 
     ruby "${TRAVIS_BUILD_DIR}/bin/openstudio_meta" install_gems --with_test_develop --debug --verbose --use_cached_gems

--- a/docker/deployment/scripts/install_openstudio.sh
+++ b/docker/deployment/scripts/install_openstudio.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This script assumes you are running as a superuser.
+
 OPENSTUDIO_VERSION=$1
 OPENSTUDIO_SHA=$2
 
@@ -13,17 +15,17 @@ if [ ! -z ${OPENSTUDIO_VERSION} ] && [ ! -z ${OPENSTUDIO_SHA} ]; then
     # Install gdebi, then download and install OpenStudio, then clean up.
     # gdebi handles the installation of OpenStudio's dependencies including Qt5 and Boost
     # libwxgtk3.0-0 is a new dependency as of 3/8/2018
-    sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends \
         libboost-thread1.55.0 \
         libwxgtk3.0-0 \
         gdebi-core \
         curl \
         git \
         && curl -SLO --insecure --retry 3 $OPENSTUDIO_DOWNLOAD_URL \
-        && sudo gdebi -n $OPENSTUDIO_DOWNLOAD_FILENAME \
+        && gdebi -n $OPENSTUDIO_DOWNLOAD_FILENAME \
         && rm -f $OPENSTUDIO_DOWNLOAD_FILENAME \
-        && sudo rm -rf /usr/SketchUpPlugin \
-        && sudo rm -rf /var/lib/apt/lists/*
+        && rm -rf /usr/SketchUpPlugin \
+        && rm -rf /var/lib/apt/lists/*
 else
     echo "Must pass in the OpenStudio version and sha to be installed (e.g. install_openstudio.sh 2.4.0 f58a3e1808)"
     exit 9

--- a/docker/deployment/scripts/install_ruby.sh
+++ b/docker/deployment/scripts/install_ruby.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This script assumes you are running as a superuser.
+
 RUBY_VERSION=$1
 RUBY_DOWNLOAD_SHA256=$2
 
@@ -13,12 +15,12 @@ if [ ! -z ${RUBY_VERSION} ] && [ ! -z ${RUBY_DOWNLOAD_SHA256} ]; then
 
     # Build and Install Ruby
     #   -- skip installing gem documentation
-    sudo mkdir -p /usr/local/etc \
-        && echo 'install: --no-document' | sudo tee --append /usr/local/etc/gemrc > /dev/null \
-        && echo 'update: --no-document' | sudo tee --append /usr/local/etc/gemrc > /dev/null
+    mkdir -p /usr/local/etc \
+        && echo 'install: --no-document' | tee --append /usr/local/etc/gemrc > /dev/null \
+        && echo 'update: --no-document' | tee --append /usr/local/etc/gemrc > /dev/null
 
     # install the dependencies for ruby
-    sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends \
         autoconf \
         build-essential \
         ca-certificates \
@@ -28,7 +30,7 @@ if [ ! -z ${RUBY_VERSION} ] && [ ! -z ${RUBY_DOWNLOAD_SHA256} ]; then
         libxml2-dev \
         libyaml-dev \
         zlib1g-dev \
-        && sudo rm -rf /var/lib/apt/lists/*
+        && rm -rf /var/lib/apt/lists/*
 
     curl -fSL --retry 3 -o ruby.tar.gz "http://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz" \
         && echo "${RUBY_DOWNLOAD_SHA256} *ruby.tar.gz" | sha256sum -c - \
@@ -36,16 +38,16 @@ if [ ! -z ${RUBY_VERSION} ] && [ ! -z ${RUBY_DOWNLOAD_SHA256} ]; then
         && tar -xzf ruby.tar.gz -C /tmp/ruby_src/ruby --strip-components=1 \
         && rm ruby.tar.gz \
         && cd /tmp/ruby_src/ruby \
-        && { echo '#define ENABLE_PATH_CHECK 0'; echo; cat file.c; } > file.c.new && sudo mv file.c.new file.c \
+        && { echo '#define ENABLE_PATH_CHECK 0'; echo; cat file.c; } > file.c.new && mv file.c.new file.c \
         && autoconf \
         && ./configure --disable-install-doc --enable-shared \
         && make -j"$(nproc)" \
-        && sudo make install \
-        && sudo apt-get purge -y --auto-remove \
-        && sudo gem update --system $RUBYGEMS_VERSION \
-        && sudo rm -rf /tmp/ruby_src \
+        && make install \
+        && apt-get purge -y --auto-remove \
+        && gem update --system $RUBYGEMS_VERSION \
+        && rm -rf /tmp/ruby_src \
         && cd $HOME \
-        && sudo gem install bundler --version "${BUNDLER_VERSION}" \
+        && gem install bundler --version "${BUNDLER_VERSION}" \
         && export BUNDLE_SILENCE_ROOT_WARNING=1
 else
     echo "Must pass in the Ruby version to be installed and the SHA (e.g. install_ruby.sh 2.2.4 <SHA>)"


### PR DESCRIPTION
We can safely remove the sudo commands in the scripts. Call the scripts with sudo if needed.

https://github.com/NREL/docker-openstudio/issues/35
