### PR TITLE
Check if R libraries install correctly

### DIFF
--- a/docker/R/Dockerfile
+++ b/docker/R/Dockerfile
@@ -2,7 +2,7 @@
 # DESCRIPTION:      OpenStudio Server R Container
 # TO_BUILD_AND_RUN: docker-compose up
 
-FROM nrel/openstudio-r:3.4.2
+FROM nrel/openstudio-r:3.4.2-2
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
 # Add in the additional R packages

--- a/docker/R/install_packages.R
+++ b/docker/R/install_packages.R
@@ -37,17 +37,28 @@
 # OpenStudio-R image here:
 # https://raw.githubusercontent.com/NREL/docker-openstudio-r/master/base_packages.R
 
+# Function for installing and verifying that the package was installed correctly (i.e. can be loaded)
+install_and_verify = function(package_name, configure.args=c(), repos=c('http://cloud.r-project.org','http://cran.r-project.org')){
+    print(paste('Calling install for package ', package_name, sep=''))
+    install.packages(package_name, configure.args=configure.args, repos=repos)
+    if (!require(package_name, character.only = TRUE)){
+        print('Error installing package, check log')
+        quit(status=1)
+    }
+    print(paste('Successfully installed and test loaded ', package_name, sep=''))
+}
+
 # Install Probability / Optimization / Analysis Packages
-install.packages('lhs', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('e1071', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('triangle', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('NMOF', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('mco', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('rgenoud', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('conf.design', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('combinat', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('DoE.base', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
-install.packages('sensitivity', repos=c('http://cloud.r-project.org','http://cran.r-project.org'))
+install_and_verify('lhs')
+install_and_verify('e1071')
+install_and_verify('triangle')
+install_and_verify('NMOF')
+install_and_verify('mco')
+install_and_verify('rgenoud')
+install_and_verify('conf.design')
+install_and_verify('combinat')
+install_and_verify('DoE.base')
+install_and_verify('sensitivity')
 
 # R Serve
-install.packages('Rserve', configure.args=c('PKG_CPPFLAGS=-DNODAEMON'), repos=c('http://rforge.net'))
+install_and_verify('Rserve', configure.args=c('PKG_CPPFLAGS=-DNODAEMON'), repos=c('http://rforge.net'))

--- a/server/app/lib/analysis_library/r/cluster.rb
+++ b/server/app/lib/analysis_library/r/cluster.rb
@@ -94,7 +94,7 @@ module AnalysisLibrary::R
           res <- NULL;
           starttime <- Sys.time()
           tryCatch({
-             res <- evalWithTimeout({
+             res <- R.utils::withTimeout({
              cl <- makePSOCKcluster(ips[,1], master='openstudio.server', outfile="/mnt/openstudio/log/snow.log")
               }, timeout=numunique);
               }, TimeoutException=function(ex) {


### PR DESCRIPTION
This PR adds in a new R method to check if the R packages are successfully installed. 

The issue was seen when installing a newer DoE.base package that required a new dependency to be installed in the base linux image. The first build of this PR will show a failure, demonstrating that the `install_and_verify` method correctly errors out. The second build will be after the base openstudio-r image has been updated with the change seen here: https://github.com/NREL/docker-openstudio-r/commit/0360dcd95b0fe5696c7b90e95e9ad23d6cba99e4#diff-3254677a7917c6c01f55212f86c57fbfR31 

Note that the 2.7.0 docker images will not work with DoE.base.