### PR TITLE
run data_point initialize scripts only once: at the end of initialize…

### DIFF
--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -63,10 +63,7 @@ module DjJobs
 
       # Logger for the simulate datapoint
       @sim_logger = Logger.new("#{simulation_dir}/#{@data_point.id}.log")
-
-      # Run  data point initialize script if present
-      run_script_with_args 'initialize'
-
+      
       # Error if @datapoint doesn't exist
       if @data_point.nil?
         @sim_logger = 'Could not find datapoint; @datapoint was nil'
@@ -422,10 +419,7 @@ module DjJobs
         end
 
         # Run the server data_point initialization script with defined arguments, if it exists.
-        Timeout.timeout(600) do
-          @sim_logger.debug "Running datapoint initialization file if present."
-          run_script_with_args "initialize"
-        end
+        run_script_with_args "initialize"
       end
 
       @sim_logger.info 'Finished worker initialization'
@@ -528,7 +522,6 @@ module DjJobs
 
         @sim_logger.info "Checking for presence of script file at #{script_path}"
         if File.file? script_path
-          # TODO how long do we want to set timeout?
           Utility::Oss.run_script(script_path, 4.hours, {'SCRIPT_ANALYSIS_ID' => @data_point.analysis.id, 'SCRIPT_DATA_POINT_ID' => @data_point.id}, args, @sim_logger,log_path)
         end
       rescue => e


### PR DESCRIPTION
…_worker. Timeout should be handled by Utility::OSS.run_script method, and set to 4 hours in run_script_with_args .

Fixes #424 