### PR TITLE
Update Dockerfile to NOT use develop 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # NOTES:            Currently this is one big dockerfile and non-optimal.
 
 
-ARG OPENSTUDIO_VERSION=develop
+ARG OPENSTUDIO_VERSION=2.7.1
 FROM nrel/openstudio:$OPENSTUDIO_VERSION as base
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 


### PR DESCRIPTION
this needs to be fixed.  docker-specific travis test will fail until [this pr](https://github.com/NREL/docker-openstudio/pull/46) completes

we were testing in develop branch using openstudio:develop pending 2.7.1 image, but develop was merged into master this am and this needs to be correct.