### PR TITLE
change limits back to reservations in docker swarm config file

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -11,7 +11,7 @@ services:
         constraints:
           - node.role == manager
       resources:
-        limits:
+        reservations:
           cpus: "1"
   queue:
       image: redis:4.0.6
@@ -34,7 +34,7 @@ services:
         constraints:
           - node.role == manager
       resources:
-        limits:
+        reservations:
           cpus: "1"
     command: /usr/local/bin/start-server
   web-background:
@@ -53,7 +53,7 @@ services:
         constraints:
           - node.role == manager
       resources:
-        limits:
+        reservations:
           cpus: "1"
     command: /usr/local/bin/start-web-background
   worker:
@@ -70,7 +70,7 @@ services:
       - rserve
     deploy:
       resources:
-        limits:
+        reservations:
           cpus: "1"
     command: /usr/local/bin/start-workers
   rserve:
@@ -86,7 +86,7 @@ services:
         constraints:
           - node.role == manager
       resources:
-        limits:
+        reservations:
           cpus: "1"
 volumes:
   osdata:

--- a/docker/deployment/docker-compose.aws.yml
+++ b/docker/deployment/docker-compose.aws.yml
@@ -22,7 +22,7 @@ services:
         constraints:
           - node.role == manager
       resources:
-        limits:
+        reservations:
           cpus: "1"
   web:
     image: localhost:5000/openstudio-server
@@ -64,7 +64,7 @@ services:
         constraints:
           - node.role == manager
       resources:
-        limits:
+        reservations:
           cpus: "1"
     command: /usr/local/bin/start-web-background
   worker:
@@ -82,7 +82,7 @@ services:
       - rserve
     deploy:
       resources:
-        limits:
+        reservations:
           cpus: "1"
     command: /usr/local/bin/start-workers
   rserve:
@@ -98,7 +98,7 @@ services:
         constraints:
           - node.role == manager
       resources:
-        limits:
+        reservations:
           cpus: "1"
 volumes:
   osdata:


### PR DESCRIPTION
revert docker swarm config to address https://github.com/NREL/OpenStudio-server/issues/448

must be done in combo with https://github.com/NREL/OpenStudio-PAT/pull/102 
so smaller servers will start up and not have docker resource issues