### PR TITLE
manage roo and bundler versions

### DIFF
--- a/ci/appveyor/setup.cmd
+++ b/ci/appveyor/setup.cmd
@@ -23,7 +23,7 @@ cd c:\
 curl -SLO https://rubygems.org/downloads/rubygems-update-2.6.7.gem
 C:\Ruby%RUBY_VERSION%\bin\ruby C:\Ruby%RUBY_VERSION%\bin\gem install --local C:\rubygems-update-2.6.7.gem
 C:\Ruby%RUBY_VERSION%\bin\ruby C:\Ruby%RUBY_VERSION%\bin\update_rubygems --no-ri --no-rdoc
-C:\Ruby%RUBY_VERSION%\bin\ruby C:\Ruby%RUBY_VERSION%\bin\gem update --system
+C:\Ruby%RUBY_VERSION%\bin\ruby C:\Ruby%RUBY_VERSION%\bin\gem update --system 2.7.8
 C:\Ruby%RUBY_VERSION%\bin\ruby C:\Ruby%RUBY_VERSION%\bin\gem uninstall rubygems-update -x -v 2.6.7
 C:\Ruby%RUBY_VERSION%\bin\ruby C:\projects\openstudio-server\bin\openstudio_meta install_gems --with_test_develop --debug --verbose
 cd c:\projects\openstudio-server

--- a/docker/R/Dockerfile
+++ b/docker/R/Dockerfile
@@ -17,7 +17,7 @@ RUN R CMD INSTALL /opt/openstudio/R/lib/R-packages/NRELmoo*.tar.gz /opt/openstud
 ADD /lib /opt/openstudio/R/lib
 
 # Install Gems
-RUN gem install bundler
+RUN gem install bundler -v1.16.4
 RUN cd /opt/openstudio/R/lib && bundle install --jobs=3 --retry=3
 
 ADD /start.R /start.R

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -56,6 +56,8 @@ gem 'uglifier'
 
 # don't try to install sassc 2.
 gem 'sassc', '~>1.12.1'
+# don't try to install roo 2.8.0 (requires Ruby >= 2.3.0)
+gem 'roo', '~>2.7.1'
 
 # For workers - and other dependencies for measures
 ## Commonly update gems for testing and development


### PR DESCRIPTION
Roo 2.8.0 released 1/18/2019 drops Ruby 2.2 support.