### PR TITLE
fix redis to 4.1.0 since 4.1.2 needs ruby 2.3.0

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -95,6 +95,7 @@ end
 
 # The only resque only is :docker, :docker-dev, :production
 group :development, :docker, :'docker-dev', :'docker-test', :production, :test do
+  gem 'redis', '=4.1.0' 
   gem 'resque', '~> 1.27'
   gem 'resque-web', require: 'resque_web'
 end

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -109,6 +109,7 @@ group :development, :test do
   gem 'meta_request'
 
   gem 'capybara'
+  gem 'public_suffix', '=3.0.3'
   gem 'coveralls', require: false
   gem 'rspec', '~> 3.4'
   gem 'rspec-rails'


### PR DESCRIPTION
redis gem was trying to install at version 4.1.2 which needs ruby >=2.30 so no go right now.