### PR TITLE
updating for ami 2.9.0-1 release to address R 3.6.1 update

### DIFF
--- a/server/app/lib/openstudio_server/version.rb
+++ b/server/app/lib/openstudio_server/version.rb
@@ -34,7 +34,7 @@
 # *******************************************************************************
 
 module OpenstudioServer
-  VERSION = '2.9.0'.freeze
+  VERSION = '2.9.0-1'.freeze
   # format should be ^.*\-{1}[a-z]+[0-9]+
   # for example: -rc1, -beta6, -customusecase0
   VERSION_EXT = ''.freeze # with preceding - or +


### PR DESCRIPTION
Need to increment the version to push a new AMI image as you cannot update an AMI with the same tag name. 