### PR TITLE
remove memfix-controller

### DIFF
--- a/docker/server/start-server.sh
+++ b/docker/server/start-server.sh
@@ -11,7 +11,7 @@ cd /opt/openstudio/server && bundle exec rake db:mongoid:create_indexes
 
 # The memfix-controller seems to have causes some issues with NRCan, need to revisit.
 # https://github.com/NREL/OpenStudio-server/issues/348
-ruby /usr/local/lib/memfix-controller.rb start
+#ruby /usr/local/lib/memfix-controller.rb start
 
 # AP hack for now to ensure both resque and nginx/rails are running on web.
 # Note that this will only run the analysis background queue as it is set in the docker-compose env file.


### PR DESCRIPTION
We need to remove this.  This zombie's a server cluster when it executes and makes it unrecoverable.  If new issues arise after removing this (so far they havent on NRcan / P+W branches) then those issues should be diagnosed properly and not do something like this. 