### PR TITLE
Make tmpname deprecate

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -68,7 +68,6 @@ gem 'openstudio-workflow', '= 2.0.0'
 # gem 'openstudio-workflow', path: '../../OpenStudio-workflow-gem'
 
 gem 'openstudio-analysis', '= 1.0.2'
-#gem 'openstudio-analysis', github: 'NREL/OpenStudio-analysis-gem', ref: 'b9ab977f3c45664588b8fe8d3cc49277af454d98'
 ## End commonly updated gems
 
 gem 'openstudio-aws', '0.7.0'

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -15,7 +15,7 @@ gem 'colored'
 # data modules
 gem 'jbuilder'
 gem 'nokogiri', '~> 1.8.2'
-gem 'rubyzip', '~> 1.2'
+gem 'rubyzip', '~> 1.3.0'
 gem 'tzinfo-data'
 
 # database modules
@@ -68,6 +68,7 @@ gem 'openstudio-workflow', '= 2.0.0'
 # gem 'openstudio-workflow', path: '../../OpenStudio-workflow-gem'
 
 gem 'openstudio-analysis', '= 1.0.2'
+#gem 'openstudio-analysis', github: 'NREL/OpenStudio-analysis-gem', ref: 'b9ab977f3c45664588b8fe8d3cc49277af454d98'
 ## End commonly updated gems
 
 gem 'openstudio-aws', '0.7.0'
@@ -114,7 +115,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rspec-retry'
   gem 'ruby-prof', '~> 0.15'
-  gem 'selenium-webdriver', '3.141.0'
+  gem 'selenium-webdriver'
 
   gem 'psych', '~> 3.1.0'
   gem 'rubocop', '0.64.0'

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -508,15 +508,15 @@ module DjJobs
     # This is local function for workaround until that is resolved
     #OpenStudio::Workflow.extract_archive(download_file, analysis_dir)
     def extract_archive(archive_filename, destination, overwrite = true)
+      ::Zip.sort_entries = true
       Zip::File.open(archive_filename) do |zf|
         zf.each do |f|
+          @sim_logger.info "Zip: Extracting #{f.name}"
           f_path = File.join(destination, f.name)
           FileUtils.mkdir_p(File.dirname(f_path))
-
-          if File.exist?(f_path) && overwrite
-            FileUtils.rm_rf(f_path)
-            zf.extract(f, f_path)
-          elsif !File.exist? f_path
+          if File.exist?(f_path)
+            @sim_logger.warn "SKIPPED: #{f.name}, already existed."
+          else
             zf.extract(f, f_path)
           end
         end

--- a/server/app/lib/analysis_library/r/lhs.rb
+++ b/server/app/lib/analysis_library/r/lhs.rb
@@ -243,7 +243,7 @@ module AnalysisLibrary::R
       logger.info "Creating image for #{variable.name} with samples #{samples}"
       save_file_name = nil
       if samples && samples.count > 0
-        save_file_name = "#{APP_CONFIG['server_asset_path']}/R/#{Dir::Tmpname.make_tmpname(['r_samples_plot', '.png'], nil)}"
+        save_file_name = Dir::Tmpname.create(['r_samples_plot', '.png'], "#{APP_CONFIG['server_asset_path']}/R"){}
         logger.info("R image filename is #{save_file_name}")
         # If running on Docker, then use type='cairo' to create PNG (since it is headless and cairo is installed)
         # png_type = Rails.env =~ /docker/ ? ', type="cairo"' : ''

--- a/server/app/models/analysis.rb
+++ b/server/app/models/analysis.rb
@@ -395,15 +395,15 @@ class Analysis
    # This is local function for workaround until that is resolved
    #OpenStudio::Workflow.extract_archive(download_file, analysis_dir)
   def extract_archive(archive_filename, destination, overwrite = true)
+    ::Zip.sort_entries = true
     Zip::File.open(archive_filename) do |zf|
       zf.each do |f|
+        logger.info "Extracting #{f.name}"
         f_path = File.join(destination, f.name)
         FileUtils.mkdir_p(File.dirname(f_path))
-
-        if File.exist?(f_path) && overwrite
-          FileUtils.rm_rf(f_path)
-          zf.extract(f, f_path)
-        elsif !File.exist? f_path
+        if File.exist?(f_path)
+          logger.info "SKIPPED: #{f.name}, already existed."
+        else
           zf.extract(f, f_path)
         end
       end


### PR DESCRIPTION
Dir::Tmpname.make_tmpname is deprecated in Ruby 2.5.0

fixes:
https://github.com/NREL/OpenStudio-server/issues/565