### PR TITLE
Windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,133 +1,133 @@
-language: minimal
+# language: minimal
 
-env:
-  global:
-    - USE_TESTING_TIMEOUTS: "true"
-    - OPENSTUDIO_VERSION=3.0.1 OPENSTUDIO_VERSION_SHA=09b7c8a554 OPENSTUDIO_VERSION_EXT=""
-    - DOCKER_COMPOSE_VERSION=1.21.1
-    - BUNDLE_WITHOUT=native_ext
+# env:
+#   global:
+#     - USE_TESTING_TIMEOUTS: "true"
+#     - OPENSTUDIO_VERSION=3.0.1 OPENSTUDIO_VERSION_SHA=09b7c8a554 OPENSTUDIO_VERSION_EXT=""
+#     - DOCKER_COMPOSE_VERSION=1.21.1
+#     - BUNDLE_WITHOUT=native_ext
 
-# Set the default scripts that are used for the majority of the tests in the matrix
-# redis-server now wants to bind to ipv6 ::1.  This changes this behavior. 
-before_install:
-  - ./ci/travis/setup.sh
-before_script:
-  - sudo Xvfb :99 -ac -screen 0 1024x768x8 &
-  - sleep 3
-script: ./ci/travis/test.sh
-after_failure: ./ci/travis/print_logs.sh
+# # Set the default scripts that are used for the majority of the tests in the matrix
+# # redis-server now wants to bind to ipv6 ::1.  This changes this behavior. 
+# before_install:
+#   - ./ci/travis/setup.sh
+# before_script:
+#   - sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+#   - sleep 3
+# script: ./ci/travis/test.sh
+# after_failure: ./ci/travis/print_logs.sh
 
-# Services for linux -- all instances
-services:
-  - docker
+# # Services for linux -- all instances
+# services:
+#   - docker
 
-jobs:
-  include:
-    - stage: test
-      os: linux
-      sudo: required
-      dist: bionic
-      env: BUILD_TYPE=test
-    - stage: test
-      os: linux
-      sudo: required
-      dist: bionic
-      env: BUILD_TYPE=integration
-    - stage: test
-      os: osx
-      osx_image: xcode9.4
-      env: BUILD_TYPE=test
-    - stage: test
-      os: osx
-      osx_image: xcode10.2
-      env: BUILD_TYPE=test
-    - stage: test
-      os: osx
-      osx_image: xcode11.4
-      env: BUILD_TYPE=test
-    - stage: test
-      os: osx
-      osx_image: xcode9.4
-      env: BUILD_TYPE=integration
-    - stage: test
-      os: osx
-      osx_image: xcode10.2
-      env: BUILD_TYPE=integration
-    - stage: test
-      os: osx
-      osx_image: xcode11.4
-      env: BUILD_TYPE=integration
-    - stage: test
-      os: linux
-      sudo: required
-      dist: bionic
-      env:
-        - CI=true
-        - OS_SERVER_NUMBER_OF_WORKERS=4
-        - BUILD_TYPE=docker
-      before_script:
-        # remove the .git in the .dockerignore so coverage can be reported correctly to coveralls
-        #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
-        - export OPENSTUDIO_TAG=develop
-        - sed -i -E "s/.git//g" .dockerignore
-        - docker volume create --name=osdata
-        - docker images --all
-        - docker --version
-        - docker-compose --version
-        - docker-compose -f docker-compose.test.yml pull
-        - docker-compose -f docker-compose.test.yml build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG
-        - docker-compose -f docker-compose.test.yml up -d
-      script:
-        - docker-compose exec web /usr/local/bin/run-server-tests
-        - docker-compose stop
-      after_script:
-        # Reset the git checkout to remove the test-based data in the containers and rebuild
-        - git checkout -- .dockerignore && git checkout -- Dockerfile
+# jobs:
+#   include:
+#     - stage: test
+#       os: linux
+#       sudo: required
+#       dist: bionic
+#       env: BUILD_TYPE=test
+#     - stage: test
+#       os: linux
+#       sudo: required
+#       dist: bionic
+#       env: BUILD_TYPE=integration
+#     - stage: test
+#       os: osx
+#       osx_image: xcode9.4
+#       env: BUILD_TYPE=test
+#     - stage: test
+#       os: osx
+#       osx_image: xcode10.2
+#       env: BUILD_TYPE=test
+#     - stage: test
+#       os: osx
+#       osx_image: xcode11.4
+#       env: BUILD_TYPE=test
+#     - stage: test
+#       os: osx
+#       osx_image: xcode9.4
+#       env: BUILD_TYPE=integration
+#     - stage: test
+#       os: osx
+#       osx_image: xcode10.2
+#       env: BUILD_TYPE=integration
+#     - stage: test
+#       os: osx
+#       osx_image: xcode11.4
+#       env: BUILD_TYPE=integration
+#     - stage: test
+#       os: linux
+#       sudo: required
+#       dist: bionic
+#       env:
+#         - CI=true
+#         - OS_SERVER_NUMBER_OF_WORKERS=4
+#         - BUILD_TYPE=docker
+#       before_script:
+#         # remove the .git in the .dockerignore so coverage can be reported correctly to coveralls
+#         #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
+#         - export OPENSTUDIO_TAG=develop
+#         - sed -i -E "s/.git//g" .dockerignore
+#         - docker volume create --name=osdata
+#         - docker images --all
+#         - docker --version
+#         - docker-compose --version
+#         - docker-compose -f docker-compose.test.yml pull
+#         - docker-compose -f docker-compose.test.yml build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG
+#         - docker-compose -f docker-compose.test.yml up -d
+#       script:
+#         - docker-compose exec web /usr/local/bin/run-server-tests
+#         - docker-compose stop
+#       after_script:
+#         # Reset the git checkout to remove the test-based data in the containers and rebuild
+#         - git checkout -- .dockerignore && git checkout -- Dockerfile
 
-    - stage: publish
-      # Include your branch name below to publish a custom image.
-      # This change must be made in combination with a modification to
-      # deployment/scripts/deploy_docker.sh, as indicated in comments for that file.
-      # Full documentation at https://github.com/NREL/OpenStudio-server/wiki/Contributor-Docs:-Building-and-Publishing-Docker-images
-      if: branch = master OR branch = develop
-      os: linux
-      sudo: required
-      dist: bionic
-      env:
-        - BUILD_TYPE=docker
-      before_script:
-        #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
-        - export OPENSTUDIO_TAG=develop
-        - docker images --all
-        - docker --version
-        - docker-compose --version
-        - docker volume create --name=osdata
-        - docker-compose build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG web
-        - docker-compose build rserve
-      script: ./docker/deployment/scripts/deploy_docker.sh
-    - stage: publish
-      if: branch = master OR branch = develop
-      os: osx
-      osx_image: xcode10.2
-      sudo: required
-      env:
-        - BUILD_TYPE=export
-      before_script:
-      script: ./ci/travis/export_build_osx.sh
-    - stage: publish
-      if: branch = master OR branch = develop
-      os: linux
-      dist: bionic
-      sudo: required
-      env:
-        - BUILD_TYPE=export
-      before_script:
-      script: ./ci/travis/export_build_linux.sh
+#     - stage: publish
+#       # Include your branch name below to publish a custom image.
+#       # This change must be made in combination with a modification to
+#       # deployment/scripts/deploy_docker.sh, as indicated in comments for that file.
+#       # Full documentation at https://github.com/NREL/OpenStudio-server/wiki/Contributor-Docs:-Building-and-Publishing-Docker-images
+#       if: branch = master OR branch = develop
+#       os: linux
+#       sudo: required
+#       dist: bionic
+#       env:
+#         - BUILD_TYPE=docker
+#       before_script:
+#         #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
+#         - export OPENSTUDIO_TAG=develop
+#         - docker images --all
+#         - docker --version
+#         - docker-compose --version
+#         - docker volume create --name=osdata
+#         - docker-compose build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG web
+#         - docker-compose build rserve
+#       script: ./docker/deployment/scripts/deploy_docker.sh
+#     - stage: publish
+#       if: branch = master OR branch = develop
+#       os: osx
+#       osx_image: xcode10.2
+#       sudo: required
+#       env:
+#         - BUILD_TYPE=export
+#       before_script:
+#       script: ./ci/travis/export_build_osx.sh
+#     - stage: publish
+#       if: branch = master OR branch = develop
+#       os: linux
+#       dist: bionic
+#       sudo: required
+#       env:
+#         - BUILD_TYPE=export
+#       before_script:
+#       script: ./ci/travis/export_build_linux.sh
 
-notifications:
-  slack:
-    on_pull_requests: true
-    on_success: change
-    on_failure: change
-    rooms:
-      secure: G5hoK8S1gFT/rZ3L1+SNHITDQSZaLIhEPb4/12TXoUuNK15SFWjr99updPBO8f04dS7GGS7MlzWvoXiLFujDWyWdb2v6wWw6A810ZU2u3KwFfevb1ewR+oxUdWfk0DI/PY2opdMyhC9YoHfSV4wo/IG659kXKKLOVBBqKKdhjMQJNHWIRiT7LgpYqlB1TRHfcxIlL2e/cIAIzVsj3o2vwgd7uFPdwVI9tzHSJlZyptOxWvQ0IVmNksSLNxaJLwHRs7cdrV5dcH+jLJaz2Kwdcu3b/0baaFGfQMKhQrTefLlESN7SjR5vzrh7Us0Y6fuOEa652bVy/gTkWGcw9F5x200vYuQSov3kPO8wxGSe9haMMkZ231jZW9Zi3VyhzDAe0eNnwxo42drOumrjK3ukvAXB4OTptxUlukvHT7DY5VcatTefI0zDt9aYA3/JLjqrxfcCweWs2IAiaapJRTSnpk+hKgDFxOh2FxohTOg/kH8f9omjg3RyJsy/wCggx12baUuyfKcOAseGtZQaXcKJ7An8epHUx8SV5ZmRUWSthDmiEcT7UmFfVqk+O0VM5gGvrgsiUvoRqs5/7fFEXAUP+djVAnd7Do4HTwG8ELgqmN0WnpNrujSenE9hQ1cou897/JTGHcqL+rwOcLEteo6VqJMVeRfsSB96hpU9faX5bE0=
+# notifications:
+#   slack:
+#     on_pull_requests: true
+#     on_success: change
+#     on_failure: change
+#     rooms:
+#       secure: G5hoK8S1gFT/rZ3L1+SNHITDQSZaLIhEPb4/12TXoUuNK15SFWjr99updPBO8f04dS7GGS7MlzWvoXiLFujDWyWdb2v6wWw6A810ZU2u3KwFfevb1ewR+oxUdWfk0DI/PY2opdMyhC9YoHfSV4wo/IG659kXKKLOVBBqKKdhjMQJNHWIRiT7LgpYqlB1TRHfcxIlL2e/cIAIzVsj3o2vwgd7uFPdwVI9tzHSJlZyptOxWvQ0IVmNksSLNxaJLwHRs7cdrV5dcH+jLJaz2Kwdcu3b/0baaFGfQMKhQrTefLlESN7SjR5vzrh7Us0Y6fuOEa652bVy/gTkWGcw9F5x200vYuQSov3kPO8wxGSe9haMMkZ231jZW9Zi3VyhzDAe0eNnwxo42drOumrjK3ukvAXB4OTptxUlukvHT7DY5VcatTefI0zDt9aYA3/JLjqrxfcCweWs2IAiaapJRTSnpk+hKgDFxOh2FxohTOg/kH8f9omjg3RyJsy/wCggx12baUuyfKcOAseGtZQaXcKJ7An8epHUx8SV5ZmRUWSthDmiEcT7UmFfVqk+O0VM5gGvrgsiUvoRqs5/7fFEXAUP+djVAnd7Do4HTwG8ELgqmN0WnpNrujSenE9hQ1cou897/JTGHcqL+rwOcLEteo6VqJMVeRfsSB96hpU9faX5bE0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,133 +1,133 @@
-# language: minimal
+language: minimal
 
-# env:
-#   global:
-#     - USE_TESTING_TIMEOUTS: "true"
-#     - OPENSTUDIO_VERSION=3.0.1 OPENSTUDIO_VERSION_SHA=09b7c8a554 OPENSTUDIO_VERSION_EXT=""
-#     - DOCKER_COMPOSE_VERSION=1.21.1
-#     - BUNDLE_WITHOUT=native_ext
+env:
+  global:
+    - USE_TESTING_TIMEOUTS: "true"
+    - OPENSTUDIO_VERSION=3.0.1 OPENSTUDIO_VERSION_SHA=09b7c8a554 OPENSTUDIO_VERSION_EXT=""
+    - DOCKER_COMPOSE_VERSION=1.21.1
+    - BUNDLE_WITHOUT=native_ext
 
-# # Set the default scripts that are used for the majority of the tests in the matrix
-# # redis-server now wants to bind to ipv6 ::1.  This changes this behavior. 
-# before_install:
-#   - ./ci/travis/setup.sh
-# before_script:
-#   - sudo Xvfb :99 -ac -screen 0 1024x768x8 &
-#   - sleep 3
-# script: ./ci/travis/test.sh
-# after_failure: ./ci/travis/print_logs.sh
+# Set the default scripts that are used for the majority of the tests in the matrix
+# redis-server now wants to bind to ipv6 ::1.  This changes this behavior. 
+before_install:
+  - ./ci/travis/setup.sh
+before_script:
+  - sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+  - sleep 3
+script: ./ci/travis/test.sh
+after_failure: ./ci/travis/print_logs.sh
 
-# # Services for linux -- all instances
-# services:
-#   - docker
+# Services for linux -- all instances
+services:
+  - docker
 
-# jobs:
-#   include:
-#     - stage: test
-#       os: linux
-#       sudo: required
-#       dist: bionic
-#       env: BUILD_TYPE=test
-#     - stage: test
-#       os: linux
-#       sudo: required
-#       dist: bionic
-#       env: BUILD_TYPE=integration
-#     - stage: test
-#       os: osx
-#       osx_image: xcode9.4
-#       env: BUILD_TYPE=test
-#     - stage: test
-#       os: osx
-#       osx_image: xcode10.2
-#       env: BUILD_TYPE=test
-#     - stage: test
-#       os: osx
-#       osx_image: xcode11.4
-#       env: BUILD_TYPE=test
-#     - stage: test
-#       os: osx
-#       osx_image: xcode9.4
-#       env: BUILD_TYPE=integration
-#     - stage: test
-#       os: osx
-#       osx_image: xcode10.2
-#       env: BUILD_TYPE=integration
-#     - stage: test
-#       os: osx
-#       osx_image: xcode11.4
-#       env: BUILD_TYPE=integration
-#     - stage: test
-#       os: linux
-#       sudo: required
-#       dist: bionic
-#       env:
-#         - CI=true
-#         - OS_SERVER_NUMBER_OF_WORKERS=4
-#         - BUILD_TYPE=docker
-#       before_script:
-#         # remove the .git in the .dockerignore so coverage can be reported correctly to coveralls
-#         #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
-#         - export OPENSTUDIO_TAG=develop
-#         - sed -i -E "s/.git//g" .dockerignore
-#         - docker volume create --name=osdata
-#         - docker images --all
-#         - docker --version
-#         - docker-compose --version
-#         - docker-compose -f docker-compose.test.yml pull
-#         - docker-compose -f docker-compose.test.yml build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG
-#         - docker-compose -f docker-compose.test.yml up -d
-#       script:
-#         - docker-compose exec web /usr/local/bin/run-server-tests
-#         - docker-compose stop
-#       after_script:
-#         # Reset the git checkout to remove the test-based data in the containers and rebuild
-#         - git checkout -- .dockerignore && git checkout -- Dockerfile
+jobs:
+  include:
+    - stage: test
+      os: linux
+      sudo: required
+      dist: bionic
+      env: BUILD_TYPE=test
+    - stage: test
+      os: linux
+      sudo: required
+      dist: bionic
+      env: BUILD_TYPE=integration
+    - stage: test
+      os: osx
+      osx_image: xcode9.4
+      env: BUILD_TYPE=test
+    - stage: test
+      os: osx
+      osx_image: xcode10.2
+      env: BUILD_TYPE=test
+    - stage: test
+      os: osx
+      osx_image: xcode11.4
+      env: BUILD_TYPE=test
+    - stage: test
+      os: osx
+      osx_image: xcode9.4
+      env: BUILD_TYPE=integration
+    - stage: test
+      os: osx
+      osx_image: xcode10.2
+      env: BUILD_TYPE=integration
+    - stage: test
+      os: osx
+      osx_image: xcode11.4
+      env: BUILD_TYPE=integration
+    - stage: test
+      os: linux
+      sudo: required
+      dist: bionic
+      env:
+        - CI=true
+        - OS_SERVER_NUMBER_OF_WORKERS=4
+        - BUILD_TYPE=docker
+      before_script:
+        # remove the .git in the .dockerignore so coverage can be reported correctly to coveralls
+        #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
+        - export OPENSTUDIO_TAG=develop
+        - sed -i -E "s/.git//g" .dockerignore
+        - docker volume create --name=osdata
+        - docker images --all
+        - docker --version
+        - docker-compose --version
+        - docker-compose -f docker-compose.test.yml pull
+        - docker-compose -f docker-compose.test.yml build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG
+        - docker-compose -f docker-compose.test.yml up -d
+      script:
+        - docker-compose exec web /usr/local/bin/run-server-tests
+        - docker-compose stop
+      after_script:
+        # Reset the git checkout to remove the test-based data in the containers and rebuild
+        - git checkout -- .dockerignore && git checkout -- Dockerfile
 
-#     - stage: publish
-#       # Include your branch name below to publish a custom image.
-#       # This change must be made in combination with a modification to
-#       # deployment/scripts/deploy_docker.sh, as indicated in comments for that file.
-#       # Full documentation at https://github.com/NREL/OpenStudio-server/wiki/Contributor-Docs:-Building-and-Publishing-Docker-images
-#       if: branch = master OR branch = develop
-#       os: linux
-#       sudo: required
-#       dist: bionic
-#       env:
-#         - BUILD_TYPE=docker
-#       before_script:
-#         #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
-#         - export OPENSTUDIO_TAG=develop
-#         - docker images --all
-#         - docker --version
-#         - docker-compose --version
-#         - docker volume create --name=osdata
-#         - docker-compose build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG web
-#         - docker-compose build rserve
-#       script: ./docker/deployment/scripts/deploy_docker.sh
-#     - stage: publish
-#       if: branch = master OR branch = develop
-#       os: osx
-#       osx_image: xcode10.2
-#       sudo: required
-#       env:
-#         - BUILD_TYPE=export
-#       before_script:
-#       script: ./ci/travis/export_build_osx.sh
-#     - stage: publish
-#       if: branch = master OR branch = develop
-#       os: linux
-#       dist: bionic
-#       sudo: required
-#       env:
-#         - BUILD_TYPE=export
-#       before_script:
-#       script: ./ci/travis/export_build_linux.sh
+    - stage: publish
+      # Include your branch name below to publish a custom image.
+      # This change must be made in combination with a modification to
+      # deployment/scripts/deploy_docker.sh, as indicated in comments for that file.
+      # Full documentation at https://github.com/NREL/OpenStudio-server/wiki/Contributor-Docs:-Building-and-Publishing-Docker-images
+      if: branch = master OR branch = develop
+      os: linux
+      sudo: required
+      dist: bionic
+      env:
+        - BUILD_TYPE=docker
+      before_script:
+        #- export OPENSTUDIO_TAG=$(ruby -e "load 'server/app/lib/openstudio_server/version.rb'; print OpenstudioServer::VERSION+OpenstudioServer::VERSION_EXT")
+        - export OPENSTUDIO_TAG=develop
+        - docker images --all
+        - docker --version
+        - docker-compose --version
+        - docker volume create --name=osdata
+        - docker-compose build --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_TAG web
+        - docker-compose build rserve
+      script: ./docker/deployment/scripts/deploy_docker.sh
+    - stage: publish
+      if: branch = master OR branch = develop
+      os: osx
+      osx_image: xcode10.2
+      sudo: required
+      env:
+        - BUILD_TYPE=export
+      before_script:
+      script: ./ci/travis/export_build_osx.sh
+    - stage: publish
+      if: branch = master OR branch = develop
+      os: linux
+      dist: bionic
+      sudo: required
+      env:
+        - BUILD_TYPE=export
+      before_script:
+      script: ./ci/travis/export_build_linux.sh
 
-# notifications:
-#   slack:
-#     on_pull_requests: true
-#     on_success: change
-#     on_failure: change
-#     rooms:
-#       secure: G5hoK8S1gFT/rZ3L1+SNHITDQSZaLIhEPb4/12TXoUuNK15SFWjr99updPBO8f04dS7GGS7MlzWvoXiLFujDWyWdb2v6wWw6A810ZU2u3KwFfevb1ewR+oxUdWfk0DI/PY2opdMyhC9YoHfSV4wo/IG659kXKKLOVBBqKKdhjMQJNHWIRiT7LgpYqlB1TRHfcxIlL2e/cIAIzVsj3o2vwgd7uFPdwVI9tzHSJlZyptOxWvQ0IVmNksSLNxaJLwHRs7cdrV5dcH+jLJaz2Kwdcu3b/0baaFGfQMKhQrTefLlESN7SjR5vzrh7Us0Y6fuOEa652bVy/gTkWGcw9F5x200vYuQSov3kPO8wxGSe9haMMkZ231jZW9Zi3VyhzDAe0eNnwxo42drOumrjK3ukvAXB4OTptxUlukvHT7DY5VcatTefI0zDt9aYA3/JLjqrxfcCweWs2IAiaapJRTSnpk+hKgDFxOh2FxohTOg/kH8f9omjg3RyJsy/wCggx12baUuyfKcOAseGtZQaXcKJ7An8epHUx8SV5ZmRUWSthDmiEcT7UmFfVqk+O0VM5gGvrgsiUvoRqs5/7fFEXAUP+djVAnd7Do4HTwG8ELgqmN0WnpNrujSenE9hQ1cou897/JTGHcqL+rwOcLEteo6VqJMVeRfsSB96hpU9faX5bE0=
+notifications:
+  slack:
+    on_pull_requests: true
+    on_success: change
+    on_failure: change
+    rooms:
+      secure: G5hoK8S1gFT/rZ3L1+SNHITDQSZaLIhEPb4/12TXoUuNK15SFWjr99updPBO8f04dS7GGS7MlzWvoXiLFujDWyWdb2v6wWw6A810ZU2u3KwFfevb1ewR+oxUdWfk0DI/PY2opdMyhC9YoHfSV4wo/IG659kXKKLOVBBqKKdhjMQJNHWIRiT7LgpYqlB1TRHfcxIlL2e/cIAIzVsj3o2vwgd7uFPdwVI9tzHSJlZyptOxWvQ0IVmNksSLNxaJLwHRs7cdrV5dcH+jLJaz2Kwdcu3b/0baaFGfQMKhQrTefLlESN7SjR5vzrh7Us0Y6fuOEa652bVy/gTkWGcw9F5x200vYuQSov3kPO8wxGSe9haMMkZ231jZW9Zi3VyhzDAe0eNnwxo42drOumrjK3ukvAXB4OTptxUlukvHT7DY5VcatTefI0zDt9aYA3/JLjqrxfcCweWs2IAiaapJRTSnpk+hKgDFxOh2FxohTOg/kH8f9omjg3RyJsy/wCggx12baUuyfKcOAseGtZQaXcKJ7An8epHUx8SV5ZmRUWSthDmiEcT7UmFfVqk+O0VM5gGvrgsiUvoRqs5/7fFEXAUP+djVAnd7Do4HTwG8ELgqmN0WnpNrujSenE9hQ1cou897/JTGHcqL+rwOcLEteo6VqJMVeRfsSB96hpU9faX5bE0=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,12 @@ environment:
   OPENSTUDIO_VERSION_EXT: ""
   OPENSTUDIO_TEST_EXE: C:\projects\openstudio\bin\openstudio.exe
 
-  init:
-    # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+artifacts:
+  - path: ci/appveyor/config.yml #relative to root of repo
+    name: artifact_test.yml
+
+init:
+  # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 clone_folder: C:\projects\openstudio-server
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,6 @@ test_script:
   - cmd: C:\projects\openstudio-server\ci\appveyor\unit-test.cmd
 on_finish:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd
-     - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 on_failure:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,9 @@ before_test:
 test_script:
   - ps: C:\projects\openstudio-server\ci\appveyor\integration-test.ps1
   - cmd: C:\projects\openstudio-server\ci\appveyor\unit-test.cmd
+  - cmd: C:\projects\openstudio-server\ci\appveyor\build_package.cmd #artifact upload occurs before on_finish
 on_finish:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd
-  - cmd: C:\projects\openstudio-server\ci\appveyor\build_package.cmd
   # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 on_failure:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,12 @@ environment:
   OPENSTUDIO_VERSION_SHA: 09b7c8a554
   OPENSTUDIO_VERSION_EXT: ""
   OPENSTUDIO_TEST_EXE: C:\projects\openstudio\bin\openstudio.exe
-  RUBY_VERSION: 25-x64
-  BUNDLER_VERSION: 2.1.0
-  BUNDLE_WITHOUT: native_ext
+  # RUBY_VERSION: 25-x64
+  # BUNDLER_VERSION: 2.1.0
+  # BUNDLE_WITHOUT: native_ext
 
-  #init:
-        #  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  init:
+         - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 clone_folder: C:\projects\openstudio-server
 
@@ -33,6 +33,6 @@ test_script:
   - cmd: C:\projects\openstudio-server\ci\appveyor\unit-test.cmd
 on_finish:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd
-    #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+     - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 on_failure:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ environment:
   OPENSTUDIO_VERSION_SHA: 09b7c8a554
   OPENSTUDIO_VERSION_EXT: ""
   OPENSTUDIO_TEST_EXE: C:\projects\openstudio\bin\openstudio.exe
-  # RUBY_VERSION: 25-x64
-  # BUNDLER_VERSION: 2.1.0
-  # BUNDLE_WITHOUT: native_ext
 
   init:
     # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   # BUNDLE_WITHOUT: native_ext
 
   init:
-         - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 clone_folder: C:\projects\openstudio-server
 
@@ -33,6 +33,6 @@ test_script:
   - cmd: C:\projects\openstudio-server\ci\appveyor\unit-test.cmd
 on_finish:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd
-  # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 on_failure:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,11 @@ environment:
   OPENSTUDIO_TEST_EXE: C:\projects\openstudio\bin\openstudio.exe
 
 artifacts:
-  - path: ci/appveyor/config.yml #relative to root of repo
-    name: artifact_test.yml
+  - path: 'export/*.tar.gz' #relative to root of repo
+    name: oss.tar.gz
 
-init:
-  # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# init:
+    # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 clone_folder: C:\projects\openstudio-server
 
@@ -34,6 +34,7 @@ test_script:
   - cmd: C:\projects\openstudio-server\ci\appveyor\unit-test.cmd
 on_finish:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - cmd: C:\projects\openstudio-server\ci\appveyor\build_package.cmd
+  # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 on_failure:
   - cmd: C:\projects\openstudio-server\ci\appveyor\print_logs.cmd

--- a/ci/appveyor/build_package.cmd
+++ b/ci/appveyor/build_package.cmd
@@ -1,0 +1,11 @@
+set PATH=C:\projects\ruby\bin;C:\Program Files\Git\mingw64\bin;C:\projects\openstudio\bin;%PATH%
+set GEM_HOME=C:\projects\openstudio-server\gems
+set GEM_PATH=C:\projects\openstudio-server\gems;C:\projects\openstudio-server\gems\gems\bundler\gems
+set RUBYLIB=C:\projects\openstudio\Ruby
+set OPENSTUDIO_TEST_EXE=C:\projects\openstudio\bin\openstudio
+REM set mongo_dir??
+cd c:\
+mkdir export
+ruby C:\projects\openstudio-server\bin\openstudio_meta install_gems --export="C:\export"
+mv C:\export C:\projects\openstudio-server\export
+dir C:\projects\openstudio-server\export

--- a/ci/appveyor/setup.cmd
+++ b/ci/appveyor/setup.cmd
@@ -1,4 +1,4 @@
-set PATH=C:\Program Files\Git\mingw64\bin;C:\projects\openstudio\bin;%PATH%
+set PATH=C:\projects\ruby\bin;C:\Program Files\Git\mingw64\bin;C:\projects\openstudio\bin;%PATH%
 set GEM_HOME=C:\projects\openstudio-server\gems
 set GEM_PATH=C:\projects\openstudio-server\gems;C:\projects\openstudio-server\gems\gems\bundler\gems
 echo Downloading and Installing OpenStudio (develop branch, %OPENSTUDIO_VERSION%%OPENSTUDIO_VERSION_EXT%+%OPENSTUDIO_VERSION_SHA%)
@@ -7,14 +7,16 @@ set OS_INSTALL_NAME=OpenStudio-%OPENSTUDIO_VERSION%%OPENSTUDIO_VERSION_EXT%%%2B%
 echo Install name is %OS_INSTALL_NAME%
 curl -SLO --insecure https://openstudio-builds.s3.amazonaws.com/%OPENSTUDIO_VERSION%/%OS_INSTALL_NAME%
 dir .
+REM Install OpenStudio
 %OS_INSTALL_NAME% --script ci/appveyor/install-windows.qs
 move C:\openstudio C:\projects\openstudio
 dir C:\projects\openstudio
 dir C:\projects\openstudio\Ruby
+rm %OS_INSTALL_NAME%
 REM install portable ruby
 curl -SLO https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/ruby-2.5.5-win32.tar.gz
-tar -xvzf ruby-2.5.5-win32.tar.gz
-
+tar -xvzf ruby-2.5.5-win32.tar.gz -C C:\projects
+rm ruby-2.5.5-win32.tar.gz
 cd c:\projects\openstudio-server
 ruby -v
 openstudio openstudio_version

--- a/ci/appveyor/setup.cmd
+++ b/ci/appveyor/setup.cmd
@@ -11,6 +11,9 @@ dir .
 move C:\openstudio C:\projects\openstudio
 dir C:\projects\openstudio
 dir C:\projects\openstudio\Ruby
+REM install portable ruby
+curl -SLO https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/ruby-2.5.5-win32.tar.gz
+tar -xvzf ruby-2.5.5-win32.tar.gz
 
 cd c:\projects\openstudio-server
 ruby -v

--- a/ci/appveyor/setup.cmd
+++ b/ci/appveyor/setup.cmd
@@ -26,6 +26,7 @@ set RUBYLIB=C:\projects\openstudio\Ruby
 ruby C:\projects\openstudio-server\bin\openstudio_meta install_gems --with_test_develop --debug --verbose
 REM dying over next 2 lines w/ "system cannot find path specified" - maybe just ruby.exe?
 cd c:\projects\openstudio-server
-C:\Ruby%RUBY_VERSION%\bin\ruby C:\Ruby%RUBY_VERSION%\bin\bundle install
+which bundle
+bundle install
 REM echo List out the test Directory
 REM dir C:\projects\openstudio-server\spec\files\


### PR DESCRIPTION
This uploads the Windows package to Appveyor's cloud storage for every build. It can be accessed from the Appveyor UI via the "Artifacts" tab for the build.  

For testing, I manually copied the package to S3: https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/OpenStudio-server-20cc98e6f3-win32.tar.gz.  I'll kick off PAT build now.

We will want a final pass to upload these to the correct s3 bucket.

Closes #505 