### PR TITLE
Update mongo and redis

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
-REDIS_URL=redis://:openstudio@queue:6379
+REDIS_PASSWORD=openstudio
+REDIS_URL=redis://:${REDIS_PASSWORD}@queue:6379
 MONGO_USER=openstudio
 MONGO_PASSWORD=openstudio

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+REDIS_URL=redis://:openstudio@queue:6379
+MONGO_USER=openstudio
+MONGO_PASSWORD=openstudio

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 REDIS_PASSWORD=openstudio
-REDIS_URL=redis://:${REDIS_PASSWORD}@queue:6379
+REDIS_URL=redis://:openstudio@queue:6379
 MONGO_USER=openstudio
 MONGO_PASSWORD=openstudio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,70 @@
 OpenStudio Server
 =================
 
+Version 3.1.0-1
+-------------
+
+* #[613](https://github.com/NREL/OpenStudio-server/pull/613/files) Update Mongo and Redis versions and allow for custom password for both Redis and Mongo when launching OpenStudio-server.  
+
+
+Version 3.1.0
+-------------
+
+Date Range 06/26/20 - 10/26/20
+
+* [#555](https://github.com/NREL/OpenStudio-server/pull/555) - Update Ruby gem envs in the openstudio_meta cli  
+* [#561](https://github.com/NREL/OpenStudio-server/pull/561) - Fixes [#560](https://github.com/NREL/OpenStudio-server/issues/560) - Fixes unzip method
+* [#563](https://github.com/NREL/OpenStudio-server/pull/563) - Add linux support for extracted gems. 
+* [#564](https://github.com/NREL/OpenStudio-server/pull/564) - Remove hardcoded openstudio version and sha
+* [#566](https://github.com/NREL/OpenStudio-server/pull/566) - Make tmpname deprecate
+* [#571](https://github.com/NREL/OpenStudio-server/pull/571) - Make downloading files back to server optional 
+* [#602](https://github.com/NREL/OpenStudio-server/pull/602) - Add algorithmic test suites
+* [#597](https://github.com/NREL/OpenStudio-server/pull/597) - Save the travis gem package artifacts
+* [#599](https://github.com/NREL/OpenStudio-server/pull/599) - Save the windows gem package artifacts
+* [#580](https://github.com/NREL/OpenStudio-server/issues/580) - add report capability to PSO 
+* [#579](https://github.com/NREL/OpenStudio-server/pull/579) - Update nokogiri
+* [#585](https://github.com/NREL/OpenStudio-server/pull/585) - Update docker-compose version
+* [#589](https://github.com/NREL/OpenStudio-server/pull/589) - Use most recent rubocop rules
+
+
+Version 3.0.1
+-------------
+Date Range 04/28/20 - 06/26/20
+
+* Updated OpenStudio SDK from v3.0.0 to v3.0.1
+* Fixed [#561](https://github.com/NREL/OpenStudio-server/issues/561) #561 Fix unzipping issue.
+
+
+Version 3.0.0
+-------------
+Date Range 12/9/19 - 04/27/20
+
+* Updated OpenStudio SDK from v2.9.1 to v3.0.0
+* Updated EnergyPlus from v9.2.0 to v9.3.0
+* Updated Ruby from 2.2.4 to Ruby 2.5.5
+* Fixed [#543](https://github.com/NREL/OpenStudio-server/issues/543) Increased the scp timeouts for larger data files.
+* Fixed [#537](https://github.com/NREL/OpenStudio-server/issues/537) Added timeout settings as user args
+
+
+Version 2.9.1
+-------------
+
+Date Range 10/11/19 - 12/9/2019
+
+* Fixed [#526](https://github.com/NREL/OpenStudio-server/issues/526) Adding checks for valid CLI options and adding debug flag as optional. 
+* Updating to bson 4.50 for MongoDB support
+
+
+Version 2.9.0
+-------------
+
+Date Range 6/5/19 - 10/11/19
+
+* [#483](https://github.com/NREL/OpenStudio-server/issues/483) Added support for develop3 (3.x OpenStudio releases) 
+* [#507](https://github.com/NREL/OpenStudio-server/issues/507) Update server/Gemfile to openstudio-analysis 1.0.2 once available develop3 
+* [#503](https://github.com/NREL/OpenStudio-server/issues/503) Updated local Linux/OSX testing for 3x
+
+
 Version 2.8.1
 -------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
 # Install required libaries.
 #   realpath - needed for wait-for-it
-RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
-    echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | \
-    sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list && \
-    apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y wget gnupg \
+    && wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
+#RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
+    && echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.4 multiverse" | \
+    tee /etc/apt/sources.list.d/mongodb-org-4.4.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
         apt-transport-https \
         autoconf \
         bison \
@@ -44,7 +46,7 @@ RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F37303
         libyaml-dev \
         libice-dev \
         libsm-dev \
-        mongodb-org-tools \
+        mongodb-database-tools \
         procps \
         python-numpy \
         python3-numpy \

--- a/ci/travis/setup.sh
+++ b/ci/travis/setup.sh
@@ -30,7 +30,7 @@ else
         # Install mongodb from a download. Brew is hanging and requires building mongo. This also speeds up the builds.
         curl -SLO https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.2.tgz
         tar xvzf mongodb-macos-x86_64-4.4.2.tgz
-        cp mongodb-macos-x86_64-4.4.2.tgz/bin/* /usr/local/bin/
+        cp mongodb-macos-x86_64-4.4.2/bin/* /usr/local/bin/
         rm -r mongodb-osx*
         
         # Install openstudio -- Use the install script that is in this repo now, the one on OpenStudio/develop has changed
@@ -70,6 +70,8 @@ else
         tar xzf redis-6.0.9.tar.gz && cd redis-6.0.9
         make && sudo make install 
         sudo cp utils/systemd-redis_server.service /etc/systemd/system/redis.service
+        cd $TRAVIS_BUILD_DIR
+        rm redis-6.0.9.tar.gz
         #sudo apt-get install redis-server || true
         #sudo systemctl stop redis-server.service
         #sudo sed -e 's/^bind.*/bind 127.0.0.1/' /etc/redis/redis.conf > redis.conf

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -13,8 +13,8 @@ services:
         reservations:
           cpus: "1"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: openstudio
-      MONGO_INITDB_ROOT_PASSWORD: openstudio
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
   queue:
     image: redis:6.0.9
     ports:
@@ -28,9 +28,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=analysis_wrappers
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     volumes:
       - osdata:/mnt/openstudio
     depends_on:
@@ -48,9 +48,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=background,analyses
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio 
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     volumes:
       - osdata:/mnt/openstudio
     depends_on:
@@ -71,9 +71,9 @@ services:
     environment:
       - QUEUES=simulations
       - COUNT=1
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio 
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     volumes:
       - /mnt/openstudio
     depends_on:
@@ -103,6 +103,10 @@ services:
       resources:
         reservations:
           cpus: "1"
+    environment:
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
 volumes:
   osdata:
     external: true

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,5 +1,4 @@
 # Version used to deploy the latest version of the server from docker hub.
-
 version: '3.4'
 services:
   db:
@@ -17,11 +16,10 @@ services:
       MONGO_INITDB_ROOT_USERNAME: openstudio
       MONGO_INITDB_ROOT_PASSWORD: openstudio
   queue:
-      image: redis:6.0.9
-      ports:
-        - "6379:6379"
-   command: redis-server --requirepass ${REDIS_PASSWORD}
-
+    image: redis:6.0.9
+    ports:
+      - "6379:6379"
+    command: "redis-server --requirepass openstudio"
   web:
     image: nrel/openstudio-server:latest
     ports:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -3,7 +3,7 @@
 version: '3.4'
 services:
   db:
-    image: mongo:3.4.10
+    image: mongo:4.4.2
     ports:
       - "27017:27017"
     deploy:
@@ -13,10 +13,15 @@ services:
       resources:
         reservations:
           cpus: "1"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: openstudio
+      MONGO_INITDB_ROOT_PASSWORD: openstudio
   queue:
-      image: redis:4.0.6
+      image: redis:6.0.9
       ports:
         - "6379:6379"
+   command: redis-server --requirepass ${REDIS_PASSWORD}
+
   web:
     image: nrel/openstudio-server:latest
     ports:
@@ -25,6 +30,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=analysis_wrappers
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio
+      - MONGO_PASSWORD=openstudio
     volumes:
       - osdata:/mnt/openstudio
     depends_on:
@@ -42,6 +50,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=background,analyses
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio 
+      - MONGO_PASSWORD=openstudio
     volumes:
       - osdata:/mnt/openstudio
     depends_on:
@@ -62,6 +73,9 @@ services:
     environment:
       - QUEUES=simulations
       - COUNT=1
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio 
+      - MONGO_PASSWORD=openstudio
     volumes:
       - /mnt/openstudio
     depends_on:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -19,7 +19,7 @@ services:
     image: redis:6.0.9
     ports:
       - "6379:6379"
-    command: "redis-server --requirepass openstudio"
+    command: "redis-server --requirepass ${REDIS_PASSWORD}"
   web:
     image: nrel/openstudio-server:latest
     ports:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -8,10 +8,14 @@ services:
       - "27017:27017"
     volumes:
       - dbdata:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: openstudio
+      MONGO_INITDB_ROOT_PASSWORD: openstudio
   queue:
     image: redis:6.0.9
     ports:
       - "6379:6379"
+    command: "redis-server --requirepass openstudio"
   web:
     image: 127.0.0.1:5000/openstudio-server
     build:
@@ -22,6 +26,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=analysis_wrappers
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio
+      - MONGO_PASSWORD=openstudio
     depends_on:
       - db
       - queue
@@ -40,6 +47,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=background,analyses
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio
+      - MONGO_PASSWORD=openstudio
     depends_on:
       - db
       - queue
@@ -58,6 +68,9 @@ services:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=simulations
       - COUNT=1
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio
+      - MONGO_PASSWORD=openstudio
     depends_on:
       - web
       - db

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,8 +9,8 @@ services:
     volumes:
       - dbdata:/data/db
     environment:
-      MONGO_INITDB_ROOT_USERNAME: openstudio
-      MONGO_INITDB_ROOT_PASSWORD: openstudio
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
   queue:
     image: redis:6.0.9
     ports:
@@ -26,9 +26,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=analysis_wrappers
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - db
       - queue
@@ -47,9 +47,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=background,analyses
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - db
       - queue
@@ -68,9 +68,9 @@ services:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=simulations
       - COUNT=1
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - web
       - db
@@ -82,6 +82,9 @@ services:
     build: ./docker/R
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     volumes:
       - osdata:/mnt/openstudio
     depends_on:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,7 +15,7 @@ services:
     image: redis:6.0.9
     ports:
       - "6379:6379"
-    command: "redis-server --requirepass openstudio"
+    command: "redis-server --requirepass ${REDIS_PASSWORD}"
   web:
     image: 127.0.0.1:5000/openstudio-server
     build:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,13 +3,13 @@
 version: '3.4'
 services:
   db:
-    image: mongo:3.4.10
+    image: mongo:4.4.2
     ports:
       - "27017:27017"
     volumes:
       - dbdata:/data/db
   queue:
-    image: redis:4.0.6
+    image: redis:6.0.9
     ports:
       - "6379:6379"
   web:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - "27017:27017"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: openstudio
-      MONGO_INITDB_ROOT_PASSWORD: openstudio
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
   queue:
     image: redis:6.0.9
     ports:
@@ -32,9 +32,9 @@ services:
       - MAX_REQUESTS=10
       - MAX_POOL=10
       - QUEUES=analysis_wrappers
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - db
       - queue
@@ -56,9 +56,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=1
       - QUEUES=background,analyses
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - db
       - queue
@@ -77,9 +77,9 @@ services:
       - OS_SERVER_NUMBER_OF_WORKERS=1
       - QUEUES=simulations
       - COUNT=1
-      - REDIS_URL=redis://:openstudio@queue:6379
-      - MONGO_USER=openstudio
-      - MONGO_PASSWORD=openstudio
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - web
       - db
@@ -91,6 +91,9 @@ services:
     build: ./docker/R
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=1
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     volumes:
       - osdata:/mnt/openstudio
     depends_on:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,10 +6,14 @@ services:
     image: mongo:4.4.2
     ports:
       - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: openstudio
+      MONGO_INITDB_ROOT_PASSWORD: openstudio
   queue:
     image: redis:6.0.9
     ports:
       - "6379:6379"
+    command: "redis-server --requirepass openstudio"
   web:
     image: nrel/openstudio-server:latest
     build:
@@ -28,6 +32,9 @@ services:
       - MAX_REQUESTS=10
       - MAX_POOL=10
       - QUEUES=analysis_wrappers
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio
+      - MONGO_PASSWORD=openstudio
     depends_on:
       - db
       - queue
@@ -49,6 +56,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=1
       - QUEUES=background,analyses
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio
+      - MONGO_PASSWORD=openstudio
     depends_on:
       - db
       - queue
@@ -67,6 +77,9 @@ services:
       - OS_SERVER_NUMBER_OF_WORKERS=1
       - QUEUES=simulations
       - COUNT=1
+      - REDIS_URL=redis://:openstudio@queue:6379
+      - MONGO_USER=openstudio
+      - MONGO_PASSWORD=openstudio
     depends_on:
       - web
       - db

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,11 +3,11 @@
 version: '3.4'
 services:
   db:
-    image: mongo:3.4.10
+    image: mongo:4.4.2
     ports:
       - "27017:27017"
   queue:
-    image: redis:4.0.6
+    image: redis:6.0.9
     ports:
       - "6379:6379"
   web:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
     image: redis:6.0.9
     ports:
       - "6379:6379"
-    command: "redis-server --requirepass openstudio"
+    command: "redis-server --requirepass ${REDIS_PASSWORD}"
   web:
     image: nrel/openstudio-server:latest
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - "27017:27017"
     volumes:
       - dbdata:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
   queue:
     image: redis:6.0.9
     ports:
@@ -22,6 +25,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=analysis_wrappers
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - db
       - queue
@@ -40,6 +46,9 @@ services:
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=background,analyses
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - db
       - queue
@@ -58,6 +67,9 @@ services:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
       - QUEUES=simulations
       - COUNT=1
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     depends_on:
       - web
       - db
@@ -69,6 +81,9 @@ services:
     build: ./docker/R
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=${OS_SERVER_NUMBER_OF_WORKERS}
+      - REDIS_URL=${REDIS_URL}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASSWORD=${MONGO_PASSWORD}
     volumes:
       - osdata:/mnt/openstudio
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     image: redis:6.0.9
     ports:
       - "6379:6379"
+    command: "redis-server --requirepass ${REDIS_PASSWORD}"
   web:
     image: nrel/openstudio-server:latest
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,13 @@
 version: '3.4'
 services:
   db:
-    image: mongo:3.4.10
+    image: mongo:4.4.2
     ports:
       - "27017:27017"
     volumes:
       - dbdata:/data/db
   queue:
-    image: redis:4.0.6
+    image: redis:6.0.9
     ports:
       - "6379:6379"
   web:

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -19,7 +19,7 @@ gem 'rubyzip', '~> 2.3.0'
 gem 'tzinfo-data'
 
 # database modules
-gem 'mongoid', '~> 6.3.0' # mongoid 6.4.0 was released 3/12/18. breaks mongoid-paperclip.
+gem 'mongoid', '~> 7.2.0' # mongoid 6.4.0 was released 3/12/18. breaks mongoid-paperclip.
 gem 'mongoid-paperclip', '~> 0.0.11', require: 'mongoid_paperclip'
 gem 'paperclip', '~> 4.3.7'
 

--- a/server/app/controllers/admin_controller.rb
+++ b/server/app/controllers/admin_controller.rb
@@ -81,7 +81,7 @@ class AdminController < ApplicationController
     if $?.exitstatus.zero?
       logger.info 'Successfully extracted uploaded database dump'
 
-      exec_str = "mongorestore -d #{Mongoid.default_client.database.name} -h #{Mongoid.default_client.cluster.addresses[0].seed} --drop #{extract_dir}/#{Mongoid.default_client.database.name}"
+      exec_str = "mongorestore --username  ENV['MONGO_USERNAME'] --password  ENV['MONGO_PASSWORD']  #{Mongoid.default_client.database.name} -h #{Mongoid.default_client.cluster.addresses[0].seed} --drop #{extract_dir}/#{Mongoid.default_client.database.name}"
       `#{exec_str}`
       if $?.exitstatus.zero?
         logger.info 'Restored mongo database'

--- a/server/app/controllers/admin_controller.rb
+++ b/server/app/controllers/admin_controller.rb
@@ -81,7 +81,7 @@ class AdminController < ApplicationController
     if $?.exitstatus.zero?
       logger.info 'Successfully extracted uploaded database dump'
 
-      exec_str = "mongorestore --username  ENV['MONGO_USERNAME'] --password  ENV['MONGO_PASSWORD']  #{Mongoid.default_client.database.name} -h #{Mongoid.default_client.cluster.addresses[0].seed} --drop #{extract_dir}/#{Mongoid.default_client.database.name}"
+      exec_str = "mongorestore --username  ENV['MONGO_USERNAME'] --password  ENV['MONGO_PASSWORD'] --authenticationDatabase admin  #{Mongoid.default_client.database.name} -h #{Mongoid.default_client.cluster.addresses[0].seed} --drop #{extract_dir}/#{Mongoid.default_client.database.name}"
       `#{exec_str}`
       if $?.exitstatus.zero?
         logger.info 'Restored mongo database'
@@ -101,7 +101,7 @@ class AdminController < ApplicationController
     dump_dir = "#{APP_CONFIG['rails_tmp_path']}/#{file_prefix}_#{time_stamp}"
     FileUtils.mkdir_p(dump_dir)
 
-    exec_str = "mongodump --db #{Mongoid.default_client.database.name} --host #{Mongoid.default_client.cluster.addresses[0].seed} --out #{dump_dir}"
+    exec_str = "mongodump --username  ENV['MONGO_USERNAME'] --password  ENV['MONGO_PASSWORD'] --authenticationDatabase admin --db #{Mongoid.default_client.database.name} --host #{Mongoid.default_client.cluster.addresses[0].seed} --out #{dump_dir}"
     `#{exec_str}`
 
     if $?.exitstatus.zero?

--- a/server/app/lib/openstudio_server/version.rb
+++ b/server/app/lib/openstudio_server/version.rb
@@ -34,7 +34,7 @@
 # *******************************************************************************
 
 module OpenstudioServer
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.1.0-1'.freeze
   # format should be ^.*\-{1}[a-z]+[0-9]+
   # for example: -rc1, -beta6, -customusecase0
   VERSION_EXT = ''.freeze # with preceding - or +

--- a/server/config/initializers/redis.rb
+++ b/server/config/initializers/redis.rb
@@ -45,7 +45,8 @@ elsif ['development', 'test'].include? Rails.env
   Resque.redis = 'localhost:6379'
 else
   require 'resque'
-  uri = URI.parse(ENV['REDIS_URL'])
+  uri =  ENV.has_key?('REDIS_URL') ? ENV['REDIS_URL'] : 'queue:6379'
+  uri = URI.parse(uri)
   #Resque.redis = 'queue:6379'
   Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
 end

--- a/server/config/initializers/redis.rb
+++ b/server/config/initializers/redis.rb
@@ -45,5 +45,7 @@ elsif ['development', 'test'].include? Rails.env
   Resque.redis = 'localhost:6379'
 else
   require 'resque'
-  Resque.redis = 'queue:6379'
+  uri = URI.parse(ENV['REDIS_URL'])
+  #Resque.redis = 'queue:6379'
+  Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
 end

--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -8,6 +8,9 @@ development:
       options:
         user: <%= ENV['MONGO_USER'] %> 
         password: <%= ENV['MONGO_PASSWORD'] %> 
+        roles:
+          - 'dbOwner'
+        auth_source: admin
   options:
     raise_not_found_error: false
     log_level: :info
@@ -20,9 +23,12 @@ docker:
       options:
         user: <%= ENV['MONGO_USER'] %>
         password: <%= ENV['MONGO_PASSWORD'] %>
+        roles:
+          - 'dbOwner'     
+        auth_source: admin
   options:
     raise_not_found_error: false
-    log_level: :info
+    log_level: :debug
 docker-dev:
   clients:
     default:
@@ -32,6 +38,9 @@ docker-dev:
       options:
         user: <%= ENV['MONGO_USER'] %>
         password: <%= ENV['MONGO_PASSWORD'] %>
+        roles:
+          - 'dbOwner'
+        auth_source: admin
   options:
     raise_not_found_error: false
     log_level: :info
@@ -44,6 +53,9 @@ docker-test:
       options:
         user: <%= ENV['MONGO_USER'] %>
         password: <%= ENV['MONGO_PASSWORD'] %>
+        roles:
+          - 'dbOwner'
+        auth_source: admin
   options:
     raise_not_found_error: false
     log_level: :info
@@ -56,6 +68,9 @@ production:
       options:
         user: <%= ENV['MONGO_USER'] %>
         password: <%= ENV['MONGO_PASSWORD'] %>
+        roles:
+          - 'dbOwner'
+        auth_source: admin
   options:
     raise_not_found_error: false
     log_level: :info
@@ -69,6 +84,9 @@ local:
       options:
         user: <%= ENV['MONGO_USER'] %>
         password: <%= ENV['MONGO_PASSWORD'] %>
+        roles:
+          - 'dbOwner'
+        auth_source: admin
   options:
     raise_not_found_error: false
     log_level: :info
@@ -81,6 +99,9 @@ local-test:
       options:
         user: <%= ENV['MONGO_USER'] %>
         password: <%= ENV['MONGO_PASSWORD'] %>
+        roles:
+          - 'dbOwner'
+        auth_source: admin
   options:
     raise_not_found_error: false
     log_level: :info
@@ -97,3 +118,6 @@ test:
         max_pool_size: 1
         user: <%= ENV['MONGO_USER'] %>
         password: <%= ENV['MONGO_PASSWORD'] %>
+        roles:
+          - 'dbOwner'
+        auth_source: admin

--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -6,6 +6,8 @@ development:
         # For some reason localhost isn't working for mongo anymore
         - 127.0.0.1:27017
       options:
+        user: <%= ENV['MONGO_USER'] %> 
+        password: <%= ENV['MONGO_PASSWORD'] %> 
   options:
     raise_not_found_error: false
     log_level: :info
@@ -16,6 +18,8 @@ docker:
       hosts:
         - db:27017
       options:
+        user: <%= ENV['MONGO_USER'] %>
+        password: <%= ENV['MONGO_PASSWORD'] %>
   options:
     raise_not_found_error: false
     log_level: :info
@@ -26,6 +30,8 @@ docker-dev:
       hosts:
         - db:27017
       options:
+        user: <%= ENV['MONGO_USER'] %>
+        password: <%= ENV['MONGO_PASSWORD'] %>
   options:
     raise_not_found_error: false
     log_level: :info
@@ -36,6 +42,8 @@ docker-test:
       hosts:
         - db:27017
       options:
+        user: <%= ENV['MONGO_USER'] %>
+        password: <%= ENV['MONGO_PASSWORD'] %>
   options:
     raise_not_found_error: false
     log_level: :info
@@ -46,6 +54,8 @@ production:
       hosts:
         - localhost:27017
       options:
+        user: <%= ENV['MONGO_USER'] %>
+        password: <%= ENV['MONGO_PASSWORD'] %>
   options:
     raise_not_found_error: false
     log_level: :info
@@ -57,6 +67,8 @@ local:
         # For some reason localhost isn't working for mongo anymore
         - 127.0.0.1:<%= ENV['OS_SERVER_MONGO_PORT'] %>
       options:
+        user: <%= ENV['MONGO_USER'] %>
+        password: <%= ENV['MONGO_PASSWORD'] %>
   options:
     raise_not_found_error: false
     log_level: :info
@@ -67,6 +79,8 @@ local-test:
       hosts:
         - localhost:<%= ENV['OS_SERVER_MONGO_PORT'] %>
       options:
+        user: <%= ENV['MONGO_USER'] %>
+        password: <%= ENV['MONGO_PASSWORD'] %>
   options:
     raise_not_found_error: false
     log_level: :info
@@ -81,3 +95,5 @@ test:
         read:
           mode: :primary
         max_pool_size: 1
+        user: <%= ENV['MONGO_USER'] %>
+        password: <%= ENV['MONGO_PASSWORD'] %>

--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -28,7 +28,7 @@ docker:
         auth_source: admin
   options:
     raise_not_found_error: false
-    log_level: :debug
+    log_level: :info
 docker-dev:
   clients:
     default:


### PR DESCRIPTION
Updates mongo and redis to use the latest supported versions. Sets a user-defined password for Mongo and Redis.  

Current server mongo::3.4.10
Latest mongo: 4.4.2

Current server redis: 4.0.6
Latest redis: 6.09

This should get updated as well: https://github.com/NREL/OpenStudio-PAT/issues/173