### PR TITLE
pass in allow_disk_usage to mongo

### DIFF
--- a/server/app/controllers/pages_controller.rb
+++ b/server/app/controllers/pages_controller.rb
@@ -101,7 +101,7 @@ class PagesController < ApplicationController
     unless @current.nil?
       # aggregate results of current analysis
       aggregated_results = DataPoint.collection.aggregate(
-        [{ '$match' => { 'analysis_id' => @current.id } }, { '$group' => { '_id' => { 'analysis_id' => '$analysis_id', 'status' => '$status' }, count: { '$sum' => 1 } } }]
+        [{ '$match' => { 'analysis_id' => @current.id } }, { '$group' => { '_id' => { 'analysis_id' => '$analysis_id', 'status' => '$status' }, count: { '$sum' => 1 } } }], :allow_disk_use => true
       )
     end
     # for js


### PR DESCRIPTION
Fix #641 

Pretty simple fix for this. I captured the debug log on mongo to verify the server accepted this optional arg and it did (see allowDiskUse in capture) so this should fix the memory exceed limit, at least according to the mongo documentation.  



 conn10","msg":"Slow query","attr":{"type":"command","ns":"os_docker.data_points","command":{"aggregate":"data_points","pipeline":[{"$match":               {"analysis_id":"6b8b090f-d6c8-4751-b485-c293546efa4a"}},{"$group":{"_id":{"analysis_id":"$analysis_id","status":"$status"},"count":{"$sum":1}}}],"cursor":{},"**allowDiskUse**":true,"$db":"os_docker","lsid":{"id":{"$uuid":"2315132a-8720-4c1c-849e-       82c040c35009"}}},"planSummary":"COLLSCAN","keysExamined":0,"docsExamined":328,"cursorExhausted":true,"numYields":0,"nreturned":1,"queryHash":"793D5B3A","planCacheKey":"793D5B3A","reslen":215,"locks":{"ReplicationStateTransition":{"acquireCount":    {"w":2}},"Global":{"acquireCount":{"r":2}},"Database":{"acquireCount":{"r":2}},"Collection":{"acquireCount":{"r":2}},"Mutex":{"acquireCount":{"r":2}}},"storage":{},"protocol":"op_msg","durationMillis":1}}


