### PR TITLE
add retries to api_get_status.rb

### DIFF
--- a/docker/R/lib/api_get_status.rb
+++ b/docker/R/lib/api_get_status.rb
@@ -68,7 +68,7 @@ begin
   result[:status] = true
   result[:result] = a[:analysis][:run_flag]
 rescue => e
-  sleep(2)
+  sleep(10)
   puts "#{__FILE__} Error: #{e.message}:#{e.backtrace.join("\n")}"
   puts "#{__FILE__} get_count: #{get_count}"
   retry if get_count <= 10

--- a/docker/R/lib/api_get_status.rb
+++ b/docker/R/lib/api_get_status.rb
@@ -58,16 +58,20 @@ end
 
 result = {}
 result[:status] = false
+get_count = 0
 begin
+  get_count += 1
   a = RestClient.get "#{options[:host]}/analyses/#{options[:analysis_id]}/status.json" , {accept: :json}
-  # TODO: retries?
   raise 'Could not create datapoint' unless a.code == 200
-
+  puts "#{__FILE__} success! get_count: #{get_count}"
   a = JSON.parse(a, symbolize_names: true)
   result[:status] = true
   result[:result] = a[:analysis][:run_flag]
 rescue => e
+  sleep(2)
   puts "#{__FILE__} Error: #{e.message}:#{e.backtrace.join("\n")}"
+  puts "#{__FILE__} get_count: #{get_count}"
+  retry if get_count <= 10
   result[:status] = false
   result[:result] = true
 ensure

--- a/docker/server/nginx.conf
+++ b/docker/server/nginx.conf
@@ -49,5 +49,9 @@ http {
           expires max;
           add_header Cache-Control public;
         }
+        
+        location = /nginx {
+          stub_status;
+        }
     }
 }

--- a/docker/server/nginx.conf
+++ b/docker/server/nginx.conf
@@ -1,6 +1,6 @@
 daemon off;
 user nobody nogroup;
-worker_processes 1;
+worker_processes auto;
 error_log /dev/stderr;
 
 events {

--- a/docker/server/nginx.conf
+++ b/docker/server/nginx.conf
@@ -1,5 +1,5 @@
 daemon off;
-user nobody nogroup;
+user nginx nginx;
 worker_processes auto;
 error_log /dev/stderr;
 
@@ -13,6 +13,8 @@ http {
     passenger_friendly_error_pages on;
 
     passenger_app_env docker;
+    passenger_default_user nginx;
+    passenger_default_group nginx;
 
     include mime.types;
     default_type application/octet-stream;

--- a/docker/server/rails-entrypoint.sh
+++ b/docker/server/rails-entrypoint.sh
@@ -16,13 +16,22 @@ chmod 666 /opt/openstudio/server/log/*.log
 sleep 1
 
 echo 'Defaulting required variables which are not present'
-[ -z "$MAX_REQUESTS" ] && export MAX_REQUESTS=50;
+[ -z "$MAX_REQUESTS" ] && export MAX_REQUESTS=110;
 [ -z "$MAX_POOL" ] && export MAX_POOL=16;
 sleep 1
 
 echo 'Configuring nginx'
 { rm /opt/nginx/conf/nginx.conf && awk  -v MAX_REQUESTS=$MAX_REQUESTS '{gsub("MAX_REQUESTS_SUB", MAX_REQUESTS, $0); print}' > /opt/nginx/conf/nginx.conf; } < /opt/nginx/conf/nginx.conf
 { rm /opt/nginx/conf/nginx.conf && awk  -v MAX_POOL=$MAX_POOL '{gsub("MAX_POOL_SUB", MAX_POOL, $0); print}' > /opt/nginx/conf/nginx.conf; } < /opt/nginx/conf/nginx.conf
+# make user nginx
+useradd --system --no-create-home -G sudo --user-group -s /bin/bash nginx
+echo "nginx ALL=(ALL) NOPASSWD: /opt/nginx/sbin/nginx -t" >> /etc/sudoers
+echo "nginx ALL=(ALL) NOPASSWD: /opt/nginx/sbin/nginx -s reload" >> /etc/sudoers
+echo "nginx ALL=(ALL) NOPASSWD: /usr/bin/kill" >> /etc/sudoers
+chown nginx /opt/nginx/conf/nginx.conf
+chown nginx /opt/nginx/logs/error.log
+chown nginx /opt/nginx/logs/nginx.pid
+chown nginx /opt/nginx/sbin/nginx
 sleep 1
 
 echo 'Beginning CMD boot process.'

--- a/docker/server/run-server-tests.sh
+++ b/docker/server/run-server-tests.sh
@@ -22,6 +22,7 @@ done
 # Run only the algorithm specs. The other features/*_spec files should probably disappear and capybara/gecko
 # can be removed.
 cd /opt/openstudio/server && bundle exec rspec spec/features/docker_stack_test_apis_spec.rb; (( exit_status = exit_status || $? ))
+cd /opt/openstudio/server && bundle exec rspec spec/features/docker_stack_test_nginx_spec.rb; (( exit_status = exit_status || $? ))
 cd /opt/openstudio/server && bundle exec rspec spec/features/docker_stack_algo_spec.rb; (( exit_status = exit_status || $? ))
 if [ ! SKIP_URBANOPT_ALGO=true ]
 then

--- a/local_setup_scripts/win64/docker-compose.yml
+++ b/local_setup_scripts/win64/docker-compose.yml
@@ -17,11 +17,13 @@ services:
     image: 127.0.0.1:5000/redis
     ports:
       - "6379:6379"
+    volumes:
+      - $PWD/redis.conf:/usr/local/etc/redis/redis.conf
     deploy:
       placement:
         constraints:
           - node.role == manager
-    command: "redis-server --requirepass openstudio"
+    command: sh -c "mkdir /var/log/redis && touch /var/log/redis/redis-server.log && redis-server /usr/local/etc/redis/redis.conf --requirepass openstudio"
   web:
     image: 127.0.0.1:5000/openstudio-server
     ports:
@@ -30,8 +32,8 @@ services:
       - "443:443"
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=1
-      - MAX_REQUESTS=10
-      - MAX_POOL=10
+      - MAX_REQUESTS=110
+      - MAX_POOL=110
       - QUEUES=analysis_wrappers
       - REDIS_URL=redis://:openstudio@queue:6379
       - MONGO_USER=openstudio

--- a/local_setup_scripts/win64/docker-compose.yml
+++ b/local_setup_scripts/win64/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - "443:443"
     environment:
       - OS_SERVER_NUMBER_OF_WORKERS=1
-      - MAX_REQUESTS=110
-      - MAX_POOL=110
+      - MAX_REQUESTS=1
+      - MAX_POOL=1
       - QUEUES=analysis_wrappers
       - REDIS_URL=redis://:openstudio@queue:6379
       - MONGO_USER=openstudio

--- a/local_setup_scripts/win64/redis.conf
+++ b/local_setup_scripts/win64/redis.conf
@@ -1,0 +1,33 @@
+# Close the connection after a client is idle for N seconds (0 to disable)
+timeout 0
+
+# TCP keepalive.
+#
+# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
+# of communication. This is useful for two reasons:
+#
+# 1) Detect dead peers.
+# 2) Force network equipment in the middle to consider the connection to be
+#    alive.
+#
+# On Linux, the specified value (in seconds) is the period used to send ACKs.
+# Note that to close the connection the double of the time is needed.
+# On other kernels the period depends on the kernel configuration.
+#
+# A reasonable value for this option is 300 seconds, which is the new
+# Redis default starting with Redis 3.2.1.
+tcp-keepalive 0
+
+
+# Specify the server verbosity level.
+# This can be one of:
+# debug (a lot of information, useful for development/testing)
+# verbose (many rarely useful info, but not a mess like the debug level)
+# notice (moderately verbose, what you want in production probably)
+# warning (only very important / critical messages are logged)
+loglevel debug
+
+# Specify the log file name. Also the empty string can be used to force
+# Redis to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+logfile /var/log/redis/redis-server.log

--- a/server/app/controllers/data_points_controller.rb
+++ b/server/app/controllers/data_points_controller.rb
@@ -51,6 +51,9 @@ class DataPointsController < ApplicationController
   # GET /data_points/1.json
   def show
     logger.info "data_points_contoller.show enter"
+    logger.info "status remoteIP: #{request.remote_ip}"
+    logger.info "status IP: #{request.ip}"
+    logger.info "status request: #{request.to_s}"
     @data_point = DataPoint.find(params[:id])
     respond_to do |format|
       if @data_point

--- a/server/spec/features/docker_stack_test_apis_spec.rb
+++ b/server/spec/features/docker_stack_test_apis_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe 'TestAPIs', type: :feature do
     @bundle_cmd = BUNDLE_CMD
 
     options = { hostname: "http://#{@host}" }
-    #APP_CONFIG['os_server_host_url'] = options[:hostname]
   end
 
   it 'run api_tests', :api_tests do

--- a/server/spec/features/docker_stack_test_nginx_spec.rb
+++ b/server/spec/features/docker_stack_test_nginx_spec.rb
@@ -1,0 +1,144 @@
+# *******************************************************************************
+# OpenStudio(R), Copyright (c) 2008-2020, Alliance for Sustainable Energy, LLC.
+# All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the copyright holder nor the names of any contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission from the respective party.
+#
+# (4) Other than as required in clauses (1) and (2), distributions in any form
+# of modifications or other derivative works may not use the "OpenStudio"
+# trademark, "OS", "os", or any other confusingly similar designation without
+# specific prior written permission from Alliance for Sustainable Energy, LLC.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER, THE UNITED STATES
+# GOVERNMENT, OR ANY CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# *******************************************************************************
+
+#################################################################################
+# To Run this test manually:
+#
+#   start a server stack with /spec added and ssh into the Web container
+#   >cd /opt/openstudio/server/spec/
+#   >gem install rest-client rails_helper json rspec rspec-retry
+#   >rspec openstudio_algo_spec.rb
+#
+#################################################################################
+
+require 'rails_helper'
+require 'rest-client'
+require 'json'
+require 'csv'
+
+# Set obvious paths for start-local & run-analysis invocation
+RUBY_CMD = 'ruby'
+BUNDLE_CMD = 'bundle exec ruby'
+
+# Docker tests have these hard coded paths
+META_CLI = File.absolute_path('/opt/openstudio/bin/openstudio_meta')
+PROJECT = File.absolute_path(File.join(File.dirname(__FILE__), '../files/'))
+HOST = '127.0.0.1'
+
+puts "Project folder is: #{PROJECT}"
+puts "META_CLI is: #{META_CLI}"
+puts "App host is: http://#{HOST}"
+
+# the actual tests
+RSpec.describe 'TestAPIs', type: :feature do
+  before :all do
+    @host = HOST
+    @project = PROJECT
+    @meta_cli = META_CLI
+    @ruby_cmd = RUBY_CMD
+    @bundle_cmd = BUNDLE_CMD
+
+    options = { hostname: "http://#{@host}" }
+  end
+
+  it 'run nginx_tests', :nginx_tests do
+
+    sleep(1)
+    puts 'access main GUI page'
+    a = RestClient.get "http://#{@host}"
+    expect(a.headers[:status]).to eq("200 OK")
+    expect(a.body).not_to include "Error"
+    expect(a.body).to include "OpenStudio Cloud Management Console"
+    
+    sleep(1)
+    puts 'check nginx status'
+    a = RestClient.get "http://#{@host}/nginx"
+    puts 'expect code 200'
+    expect(a.code).to eq(200)
+    puts 'expect \'Active connections\' in body'
+    compare = a.body.include?('Active connections')
+    expect(compare).to be true
+    
+    puts 'expect user to be \'root\''
+    whoami = `whoami`
+    puts "whoami: #{whoami}"
+    expect(whoami).to eq("root\n")
+    
+    puts 'test nginx.conf file as user nginx'
+    test_config = `su nginx -c 'sudo /opt/nginx/sbin/nginx -t 2>&1'`
+    puts "test_config: #{test_config}"
+    syntax = test_config.include?('syntax is ok')
+    puts 'expect test_config to include \'syntax is ok\''
+    expect(syntax).to be true
+    successful = test_config.include?('test is successful')
+    puts 'expect test_config to include \'test is successful\''
+    expect(successful).to be true
+    
+    sleep(1)
+    puts 'get nginx processes'
+    nginx_pids = `ps aux|grep nginx`
+    expect(nginx_pids).not_to be_empty
+    puts 'get nginx PIDs'
+    nginx_worker_pids = nginx_pids.split("\n").select{ |s| s =~ /nginx: worker process$/}.map {|e| e[%r{nginx \s*\d+\s}][%r{\d+}]} if !nginx_pids.nil?
+    puts "nginx_worker_pids: #{nginx_worker_pids}"
+    expect(nginx_worker_pids).not_to be_empty
+    
+    sleep(1)
+    puts 'reload \'nginx.conf\' as user \'nginx\'' 
+    `su nginx -c 'sudo /opt/nginx/sbin/nginx -s reload'`
+    puts 'wait for 3 seconds'
+    sleep(3)
+    
+    puts 'get nginx processes'
+    nginx_pids = `ps aux|grep nginx`
+    expect(nginx_pids).not_to be_empty
+    puts 'get nginx PIDs'
+    nginx_worker_pids2 = nginx_pids.split("\n").select{ |s| s =~ /nginx: worker process$/}.map {|e| e[%r{nginx \s*\d+\s}][%r{\d+}]} if !nginx_pids.nil?
+    puts "nginx_worker_pids2: #{nginx_worker_pids2}"
+    expect(nginx_worker_pids2).not_to be_empty
+    expect(nginx_worker_pids2.is_a?(Array)).to be true
+    new_pids = nginx_worker_pids2.is_a?(Array) && !nginx_worker_pids2.any? {|pids| nginx_worker_pids.include?(pids)}
+    expect(new_pids).to be true
+    
+    sleep(1)
+    puts 'check nginx status'
+    a = RestClient.get "http://#{@host}/nginx"
+    puts 'expect code 200'
+    expect(a.code).to eq(200)
+    puts 'expect \'Active connections\' in body'
+    compare = a.body.include?('Active connections')
+    expect(compare).to be true
+  end    
+end

--- a/server/spec/features/docker_stack_test_nginx_spec.rb
+++ b/server/spec/features/docker_stack_test_nginx_spec.rb
@@ -140,5 +140,210 @@ RSpec.describe 'TestAPIs', type: :feature do
     puts 'expect \'Active connections\' in body'
     compare = a.body.include?('Active connections')
     expect(compare).to be true
+    
+    sleep(1)
+    puts 'remove any existing projects'
+    a = RestClient.get "http://#{@host}/projects.json"
+    a = JSON.parse(a, symbolize_names: true)
+    a.each do |project|
+        sleep(1)
+        id = project[:_id]
+        puts "removing existing project id: #{id}"
+        begin
+            RestClient.delete "http://#{@host}/projects/#{id}"
+        rescue RestClient::ExceptionWithResponse => err
+            case err.http_code
+            when 301, 302, 307
+                puts '   redirecting after delete'
+            end
+        end
+    end
+    
+    # the tests below submit an analysis and once that queues datapoints
+    # it submits another analysis, which will reload nginx while the other
+    # analysis is running.  the test expects both analysis to complete all 
+    # six datapoints that are successful with objective function values
+    
+    sleep(1)
+    puts 'check there are no projects'
+    a = RestClient.get "http://#{@host}/projects.json"
+    a = JSON.parse(a, symbolize_names: true)
+    expect(a).to be_empty
+    
+    sleep(1)
+    puts 'check that there are no analyses'
+    a = RestClient.get "http://#{@host}/analyses.json"
+    a = JSON.parse(a, symbolize_names: true)
+    expect(a).to be_empty
+    
+    sleep(1)
+    puts 'run a morris analysis'
+    # run an analysis
+    command = "#{@bundle_cmd} #{@meta_cli} run_analysis --debug --verbose '#{@project}/SEB_Morris_2013.json' 'http://#{@host}' -z 'SEB_calibration_NSGA_2013' -a morris"
+    puts "run command: #{command}"
+    run_analysis = system(command)
+    expect(run_analysis).to be true
+    
+    sleep(3)
+    a = RestClient.get "http://#{@host}/analyses.json"
+    a = JSON.parse(a, symbolize_names: true)
+    a = a.sort { |x, y| x[:created_at] <=> y[:created_at] }.reverse
+    expect(a).not_to be_empty
+    analysis = a[0]
+    analysis_id = analysis[:_id]
+    
+    a = RestClient.get "http://#{@host}/analyses/#{analysis_id}/status.json"
+    a = JSON.parse(a, symbolize_names: true)
+    analysis_type = a[:analysis][:analysis_type]
+    expect(analysis_type).to eq('morris')
+
+    status = a[:analysis][:status]
+    expect(status).not_to be_nil
+    puts "Accessed pages for analysis: #{analysis_id}, analysis_type: #{analysis_type}, status: #{status}"
+    
+    puts "sleep for 10 seconds"
+    sleep(10)
+    get_count = 0
+    get_count_max = 50
+    # get all data points in this analysis
+    puts 'make sure datapoints are queued or started'
+    begin
+        a = RestClient.get "http://#{@host}/data_points.json"
+        a = JSON.parse(a, symbolize_names: true)
+        data_points = []
+        a.each do |data_point|
+          if data_point[:analysis_id] == analysis_id
+            data_points << data_point
+          end
+        end
+        puts "datapoints: #{data_points}"
+        have_datapoints = !data_points.empty?
+        puts "have_datapoints: #{have_datapoints}"
+        raise if have_datapoints != true
+        # confirm that queueing is working
+        data_points.each do |data_point|
+          # get the datapoint pages
+          data_point_id = data_point[:_id]
+          expect(data_point_id).not_to be_nil
+
+          a = RestClient.get "http://#{@host}/data_points/#{data_point_id}.json"
+          a = JSON.parse(a, symbolize_names: true)
+          expect(a).not_to be_nil
+
+          data_points_status = a[:data_point][:status]
+          expect(data_points_status).not_to be_nil
+          puts "Accessed pages for data_point #{data_point_id}, data_points_status = #{data_points_status}"
+        end
+    rescue => e
+        puts "rescue: #{e} get_count: #{get_count}"
+        sleep(10)
+        retry if get_count <= get_count_max
+        expect(have_datapoints).to be true
+    end
+    
+    puts "have datapoints queued, submit another analysis"
+    #submit another job with datapoint started and queued
+    #this will reload nginx
+    # run an analysis
+    command = "#{@bundle_cmd} #{@meta_cli} run_analysis --debug --verbose '#{@project}/SEB_Morris_2013.json' 'http://#{@host}' -z 'SEB_calibration_NSGA_2013' -a morris"
+    puts "run command: #{command}"
+    run_analysis = system(command)
+    expect(run_analysis).to be true
+    
+    sleep(3)
+    a = RestClient.get "http://#{@host}/analyses.json"
+    a = JSON.parse(a, symbolize_names: true)
+    a = a.sort { |x, y| x[:created_at] <=> y[:created_at] }.reverse
+    expect(a).not_to be_empty
+    analysis = a[0]
+    new_analysis_id = analysis[:_id]
+    
+    #wait till first analysis completes
+    puts "run second analysis"
+    status = 'queued'
+    timeout_seconds = 360
+    begin
+      ::Timeout.timeout(timeout_seconds) do
+        while status != 'completed'
+          # get the analysis pages
+          get_count = 0
+          get_count_max = 50
+          begin
+            a = RestClient.get "http://#{@host}/analyses/#{analysis_id}/status.json"
+            a = JSON.parse(a, symbolize_names: true)
+
+            status = a[:analysis][:status]
+            expect(status).not_to be_nil
+            puts "Accessed pages for analysis: #{analysis_id}, analysis_type: #{analysis_type}, status: #{status}"
+
+          rescue RestClient::ExceptionWithResponse => e
+            puts "rescue: #{e} get_count: #{get_count}"
+            sleep(10.0)
+            retry if get_count <= get_count_max
+          end
+          puts ''
+          sleep 10
+        end
+      end
+    rescue ::Timeout::Error
+      puts "Analysis status is `#{status}` after #{timeout_seconds} seconds; assuming error."
+    end
+    expect(status).to eq('completed')
+
+    puts "wait for second analysis to complete"
+    #wait till second analysis completes
+    status = 'queued'
+    timeout_seconds = 360
+    begin
+      ::Timeout.timeout(timeout_seconds) do
+        while status != 'completed'
+          # get the analysis pages
+          get_count = 0
+          get_count_max = 50
+          begin
+            a = RestClient.get "http://#{@host}/analyses/#{new_analysis_id}/status.json"
+            a = JSON.parse(a, symbolize_names: true)
+
+            status = a[:analysis][:status]
+            expect(status).not_to be_nil
+            puts "Accessed pages for analysis: #{new_analysis_id}, analysis_type: #{analysis_type}, status: #{status}"
+
+          rescue RestClient::ExceptionWithResponse => e
+            puts "rescue: #{e} get_count: #{get_count}"
+            sleep(10.0)
+            retry if get_count <= get_count_max
+          end
+          puts ''
+          sleep 10
+        end
+      end
+    rescue ::Timeout::Error
+      puts "Analysis status is `#{status}` after #{timeout_seconds} seconds; assuming error."
+    end
+    expect(status).to eq('completed')
+    
+    puts "expect there to be 6 datapoints"
+    dps = RestClient.get "http://#{@host}/data_points.json"
+    dps = JSON.parse(dps, symbolize_names: true)
+    expect(dps).not_to be_nil
+    expect(dps.size).to eq(6)
+    
+    puts "confirm that all datapoints ran successfully and have objective function values"
+    dps.each do |data_point|
+        dp = RestClient.get "http://#{@host}/data_points/#{data_point[:_id]}.json"
+        dp = JSON.parse(dp, symbolize_names: true)
+        expect(dp[:data_point][:status_message]).to eq('completed normal')
+
+        results = dp[:data_point][:results][:calibration_reports_enhanced_20]
+        expect(results).not_to be_nil
+        sim = results.slice(:electricity_consumption_cvrmse, :electricity_consumption_nmbe, :natural_gas_consumption_cvrmse, :natural_gas_consumption_nmbe)
+        expect(sim.size).to eq(4)
+        sim = sim.transform_values { |x| x.truncate(4) }
+        sim.values.each do |s|
+            is_a_number = s.is_a?(Float)
+            expect(is_a_number).to be true
+        end        
+    end
+      
   end    
 end

--- a/server/spec/files/SEB_Morris_2013.json
+++ b/server/spec/files/SEB_Morris_2013.json
@@ -1318,6 +1318,8 @@
     "run_workflow_timeout": 28800,
     "upload_results_timeout": 28800,
     "initialize_worker_timeout": 28800,
+    "passenger_max_request_queue_size": 111,
+    "passenger_max_pool_size": 21,
     "server_scripts": {}
   }
 }


### PR DESCRIPTION
there can be 503 service unavailable errors when the web container gets slammed.
`[1] "run command: ruby  /opt/openstudio/R/lib/api_create_datapoint.rb -h http://web:80 -a d7fa128a-2c5b-4ce5-a601-8942f82427f6 -v -26.6666666666667,0 --submit"
[1] "Check Run Flag run command: ruby  /opt/openstudio/R/lib/api_get_status.rb -h http://web:80 -a d7fa128a-2c5b-4ce5-a601-8942f82427f6"
 [1] "Check Run Flag z: {:submit_simulation=>false, :sleep_time=>5, :host=>\"http://web:80\", :analysis_id=>\"d7fa128a-2c5b-4ce5-a601-8942f82427f6\"}"                                                                    
 [2] "Check Run Flag z: /opt/openstudio/R/lib/api_get_status.rb Error: 503 Service Unavailable:/usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient/abstract_response.rb:223:in `exception_with_response'"
 [3] "Check Run Flag z: /usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient/abstract_response.rb:103:in `return!'"                                                                                       
 [4] "Check Run Flag z: /usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient/request.rb:809:in `process_result'"                                                                                          
 [5] "Check Run Flag z: /usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient/request.rb:725:in `block in transmit'"                                                                                       
 [6] "Check Run Flag z: /usr/local/lib/ruby/2.7.0/net/http.rb:933:in `start'"                                                                                                                                             
 [7] "Check Run Flag z: /usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient/request.rb:715:in `transmit'"                                                                                                
 [8] "Check Run Flag z: /usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient/request.rb:145:in `execute'"                                                                                                 
 [9] "Check Run Flag z: /usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient/request.rb:52:in `execute'"                                                                                                  
[10] "Check Run Flag z: /usr/local/lib/ruby/gems/2.7.0/gems/rest-client-2.0.2/lib/restclient.rb:67:in `get'"                                                                                                              
[11] "Check Run Flag z: /opt/openstudio/R/lib/api_get_status.rb:62:in `<main>'"                                                                                                                                           
[12] "Check Run Flag z: {\"status\":false,\"result\":true}"                                                           
`

this should get retried 