### PR TITLE
Update api_get_status.rb

### DIFF
--- a/docker/R/lib/api_get_status.rb
+++ b/docker/R/lib/api_get_status.rb
@@ -58,16 +58,20 @@ end
 
 result = {}
 result[:status] = false
+get_count = 0
 begin
+  get_count += 1
   a = RestClient.get "#{options[:host]}/analyses/#{options[:analysis_id]}/status.json" , {accept: :json}
-  # TODO: retries?
   raise 'Could not create datapoint' unless a.code == 200
-
+  puts "#{__FILE__} success! get_count: #{get_count}"
   a = JSON.parse(a, symbolize_names: true)
   result[:status] = true
   result[:result] = a[:analysis][:run_flag]
 rescue => e
+  sleep(10)
   puts "#{__FILE__} Error: #{e.message}:#{e.backtrace.join("\n")}"
+  puts "#{__FILE__} get_count: #{get_count}"
+  retry if get_count <= 10
   result[:status] = false
   result[:result] = true
 ensure

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -19,7 +19,6 @@ gem 'rubyzip', '~> 2.3.0'
 gem 'tzinfo-data', '~>1.2021.1'
 
 # database modules
-
 gem 'mongoid', '7.2.1'
 #gem 'mongoid-paperclip' 
 # forked gem is neccessary as mongoid-paperclip relies on mimemagic which now requires freedesktop.org.xml at run time"
@@ -58,7 +57,8 @@ gem 'sass', '~> 3.7.4'
 gem 'sass-rails', '~> 6.0.0'
 gem 'sprockets-rails', '~> 3.2.2'
 gem 'uglifier', '~> 4.2.0'
-
+# mail => 2.8.0 has startup failures with rails 6.1.x series
+gem 'mail', '= 2.7.1'
 # don't try to install sassc 2.
 gem 'roo', '~> 2.8.3'
 gem 'sassc', '~> 2.4.0'


### PR DESCRIPTION
add retry to eliminate NAs when nginx is overloaded

This is a trimmed down PR to replace https://github.com/NREL/OpenStudio-server/pull/669
just add the retries to the API and do not change NGINX config