### PR TITLE
update UO for hpxml 151

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -71,7 +71,7 @@ gem 'openstudio-workflow', '= 2.3.1'
 gem 'openstudio-analysis', '= 1.2.0'
 
 # Remove urbanopt cli gems for minor for releases as they use different versions of ext gems
-gem 'urbanopt-cli', '= 0.9.0'
+gem 'urbanopt-cli', '= 0.9.1'
 gem 'urbanopt-reopt', '= 0.9.0'
 
 ## End commonly updated gems


### PR DESCRIPTION
Update UO dependency with new release of URBANopt that supports HPXML 1.5.1 (OpenStudio 3.5.1)