### PR TITLE
Using bundled ruby gems with analysis runs

### DIFF
--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -209,10 +209,10 @@ module DjJobs
               run_urbanopt(uo_simulation_log, uo_process_log)
             else  #OS CLI workflow
               @sim_logger.info "analysis is configured with #{@data_point.analysis.to_json}"
-              if @data_point.analysis.gemfile.empty?
-                cmd = "#{Utility::Oss.oscli_cmd_no_bundle_args(@sim_logger)} #{@data_point.analysis.cli_verbose} run --workflow #{osw_path} #{@data_point.analysis.cli_debug}"
+              if @data_point.analysis.gemfile
+                cmd = "#{Utility::Oss.oscli_cmd_bundle_args(@sim_logger, analysis_dir)} #{@data_point.analysis.cli_verbose} run --workflow #{osw_path} #{@data_point.analysis.cli_debug}"
               else
-                cmd = "#{Utility::Oss.oscli_cmd_bundle_args(@sim_logger, "#{analysis_dir}/#{@data_point.analysis.gemfile}", "#{analysis_dir}/gems")} #{@data_point.analysis.cli_verbose} run --workflow #{osw_path} #{@data_point.analysis.cli_debug}"
+                cmd = "#{Utility::Oss.oscli_cmd_no_bundle_args(@sim_logger)} #{@data_point.analysis.cli_verbose} run --workflow #{osw_path} #{@data_point.analysis.cli_debug}"
               end
               process_log = File.join(simulation_dir, 'oscli_simulation.log')
               @sim_logger.info "Running workflow using cmd #{cmd} and writing log to #{process_log}"
@@ -528,7 +528,7 @@ module DjJobs
 
         # Run the server data_point initialization script with defined arguments, if it exists.
         run_script_with_args 'initialize'
-        run_bundle_gems unless @data_point.analysis.gemfile.empty?
+        run_bundle_gems if @data_point.analysis.gemfile
       
       end
 
@@ -677,16 +677,15 @@ module DjJobs
 
     def run_bundle_gems
       @sim_logger.info "Installing gems" 
-      gemfile = "#{analysis_dir}/#{@data_point.analysis.gemfile}"
-      if File.file? gemfile
-        @sim_logger.info "Gemfile found at: #{gemfile}"
+      if File.file? "#{analysis_dir}/Gemfile"
+        @sim_logger.info "Gemfile found in: #{analysis_dir}"
       else
-        @sim_logger.info "Gemfile not found at #{gemfile}" 
+        @sim_logger.info "Gemfile not found at #{analysis_dir}" 
         return false
       end
 
       log_path = "#{analysis_dir}/bundle.log"
-      cmd = "bundle install --gemfile=#{gemfile} --path=#{analysis_dir}/gems"
+      cmd = "bundle install --gemfile=#{analysis_dir}/Gemfile --path=#{analysis_dir}/gems"
       oscli_env_unset = Hash[Utility::Oss::ENV_VARS_TO_UNSET_FOR_OSCLI.collect{|x| [x,nil]}]
       @sim_logger.info "Bundle install command: #{cmd}"
       pid = Process.spawn(oscli_env_unset, cmd, [:err, :out] => [log_path, 'w'])

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -676,7 +676,6 @@ module DjJobs
     end
 
     def run_bundle_gems
-
       @sim_logger.info "Installing gems" 
       gemfile = "#{analysis_dir}/#{@data_point.analysis.gemfile}"
       if File.file? gemfile

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -209,10 +209,10 @@ module DjJobs
               run_urbanopt(uo_simulation_log, uo_process_log)
             else  #OS CLI workflow
               @sim_logger.info "analysis is configured with #{@data_point.analysis.to_json}"
-              if @data_point.analysis.gemfile
-                cmd = "#{Utility::Oss.oscli_cmd_bundle_args(@sim_logger, "#{analysis_dir}/#{@data_point.analysis.gemfile}", "#{analysis_dir}/gems", )} #{@data_point.analysis.cli_verbose} run --workflow #{osw_path} #{@data_point.analysis.cli_debug}"
-              else
+              if @data_point.analysis.gemfile.empty?
                 cmd = "#{Utility::Oss.oscli_cmd_no_bundle_args(@sim_logger)} #{@data_point.analysis.cli_verbose} run --workflow #{osw_path} #{@data_point.analysis.cli_debug}"
+              else
+                cmd = "#{Utility::Oss.oscli_cmd_bundle_args(@sim_logger, "#{analysis_dir}/#{@data_point.analysis.gemfile}", "#{analysis_dir}/gems")} #{@data_point.analysis.cli_verbose} run --workflow #{osw_path} #{@data_point.analysis.cli_debug}"
               end
               process_log = File.join(simulation_dir, 'oscli_simulation.log')
               @sim_logger.info "Running workflow using cmd #{cmd} and writing log to #{process_log}"
@@ -528,7 +528,7 @@ module DjJobs
 
         # Run the server data_point initialization script with defined arguments, if it exists.
         run_script_with_args 'initialize'
-        run_bundle_gems if @data_point.analysis.gemfile
+        run_bundle_gems unless @data_point.analysis.gemfile.empty?
       
       end
 

--- a/server/app/jobs/dj_jobs/urban_opt.rb
+++ b/server/app/jobs/dj_jobs/urban_opt.rb
@@ -42,7 +42,7 @@ module DjJobs
       @sim_logger.info "@data_point.analysis.problem['workflow']: #{@data_point.analysis.problem['workflow']}"
       @sim_logger.info "@data_point.analysis.problem['workflow'].any?{|h| h['measure_type'] == 'RubyMeasure'}: #{@data_point.analysis.problem['workflow'].any?{|h| h['measure_type'] == 'RubyMeasure'}}"
       if !@data_point.analysis.problem['workflow'].empty? && @data_point.analysis.problem['workflow'].any?{|h| h['measure_type'] == 'RubyMeasure'}            
-        cmd = "#{Utility::Oss.oscli_cmd(@sim_logger)} #{@data_point.analysis.cli_verbose} run --measures_only --workflow '#{osw_path}' #{@data_point.analysis.cli_debug}"
+        cmd = "#{Utility::Oss.oscli_cmd_no_bundle_args(@sim_logger)} #{@data_point.analysis.cli_verbose} run --measures_only --workflow '#{osw_path}' #{@data_point.analysis.cli_debug}"
         process_log = File.join(simulation_dir, 'oscli_measures_only.log')
         @sim_logger.info "Running measures_only workflow using cmd #{cmd} and writing log to #{process_log}"
         oscli_env_unset = Hash[Utility::Oss::ENV_VARS_TO_UNSET_FOR_OSCLI.collect{|x| [x,nil]}]

--- a/server/app/jobs/dj_jobs/urban_opt.rb
+++ b/server/app/jobs/dj_jobs/urban_opt.rb
@@ -209,7 +209,7 @@ module DjJobs
       @sim_logger.info "@data_point.analysis.problem['workflow']: #{@data_point.analysis.problem['workflow']}"
       @sim_logger.info "@data_point.analysis.problem['workflow'].any?{|h| h['measure_type'] == 'ReportingMeasure'}: #{@data_point.analysis.problem['workflow'].any?{|h| h['measure_type'] == 'ReportingMeasure'}}"
       if !@data_point.analysis.problem['workflow'].empty? && @data_point.analysis.problem['workflow'].any?{|h| h['measure_type'] == 'ReportingMeasure'}            
-        cmd = "#{Utility::Oss.oscli_cmd(@sim_logger)} #{@data_point.analysis.cli_verbose} run --postprocess_only --workflow '#{osw_path}' #{@data_point.analysis.cli_debug}"
+        cmd = "#{Utility::Oss.oscli_cmd_no_bundle_args(@sim_logger)} #{@data_point.analysis.cli_verbose} run --postprocess_only --workflow '#{osw_path}' #{@data_point.analysis.cli_debug}"
         process_log = File.join(simulation_dir, 'oscli_postprocess_only.log')
         @sim_logger.info "Running postprocess_only workflow using cmd #{cmd} and writing log to #{process_log}"
         oscli_env_unset = Hash[Utility::Oss::ENV_VARS_TO_UNSET_FOR_OSCLI.collect{|x| [x,nil]}]

--- a/server/app/lib/analysis_library/schema/osa.json
+++ b/server/app/lib/analysis_library/schema/osa.json
@@ -150,6 +150,22 @@
 				"cli_verbose": {
 					"type": "string"
 				},
+				"download_reports": {
+					"type": "boolean"
+				},
+				"download_osw": {
+					"type": "boolean"
+				},
+				"download_osm": {
+					"type": "boolean"
+				},
+				"download_zip": {
+					"type": "boolean"
+				},
+				"gemfile": {
+					"description": "Relative path and name of the Gemfile",
+					"type": "string"
+				},
 				"initialize_worker_timeout": {
 					"type": "number"
 				},

--- a/server/app/lib/analysis_library/schema/osa.json
+++ b/server/app/lib/analysis_library/schema/osa.json
@@ -163,8 +163,8 @@
 					"type": "boolean"
 				},
 				"gemfile": {
-					"description": "Relative path and name of the Gemfile",
-					"type": "string"
+					"description": "set to true to use Gemfile",
+					"type": "boolean"
 				},
 				"initialize_worker_timeout": {
 					"type": "number"

--- a/server/app/lib/utility/oss.rb
+++ b/server/app/lib/utility/oss.rb
@@ -16,14 +16,14 @@ module Utility
       #   'BUNDLE_WITHOUT' # This now needs to be set BUNDLE_WITHOUT=native_ext
     ].freeze
     # return command to run openstudio cli on current platform
-    def self.oscli_cmd(logger = Rails.logger)
+    def self.oscli_cmd_bundle_args(logger = Rails.logger, gemfile, gempath)
       # determine if an explicit oscli path has been set via the meta-cli option, warn if not
 
       raise 'OPENSTUDIO_EXE_PATH not set' unless ENV['OPENSTUDIO_EXE_PATH']
       raise "Unable to find file specified in OPENSTUDIO_EXE_PATH: `#{ENV['OPENSTUDIO_EXE_PATH']}`" unless File.exist?(ENV['OPENSTUDIO_EXE_PATH'])
       logger.info "Found ENV['OPENSTUDIO_EXE_PATH']"
       # set cmd from ENV variable
-      cmd = ENV['OPENSTUDIO_EXE_PATH'] + oscli_bundle
+      cmd = ENV['OPENSTUDIO_EXE_PATH'] + oscli_bundle(gemfile, gempath)
       logger.info "Returning Oscli cmd: #{cmd}"
       cmd
     rescue Exception => e
@@ -34,7 +34,7 @@ module Utility
       else
         logger.error 'Unable to find Oscli.'
       end
-      logger.info "RESCUE: Returning Oscli cmd: #{cmd + oscli_bundle}"
+      logger.info "RESCUE: Returning Oscli cmd: #{cmd + oscli_bundle(gemfile, gempath)}"
       cmd + oscli_bundle
     end
     
@@ -52,10 +52,10 @@ module Utility
 
     # use bundle option only if we have a path to openstudio gemfile.
     # if BUNDLE_PATH is not set (ie Docker), we must add these options
-    def self.oscli_bundle
-      bundle = Rails.application.config.os_gemfile_path.present? ? ' --bundle '\
-      "#{File.join Rails.application.config.os_gemfile_path, 'Gemfile'} --bundle_path "\
-      "#{File.join Rails.application.config.os_gemfile_path, 'gems'} --bundle_without native_ext" : ''
+    def self.oscli_bundle(gemfile, gemdir)
+       bundle = ' --bundle '\
+      "#{gemfile} --bundle_path "\
+      "#{gemdir} --bundle_without native_ext"
     end
 
     # Set some env_vars from the running env var list, ignore the rest

--- a/server/app/lib/utility/oss.rb
+++ b/server/app/lib/utility/oss.rb
@@ -16,14 +16,14 @@ module Utility
       #   'BUNDLE_WITHOUT' # This now needs to be set BUNDLE_WITHOUT=native_ext
     ].freeze
     # return command to run openstudio cli on current platform
-    def self.oscli_cmd_bundle_args(logger = Rails.logger, gemfile, gempath)
+    def self.oscli_cmd_bundle_args(logger = Rails.logger, gemfile_dir)
       # determine if an explicit oscli path has been set via the meta-cli option, warn if not
 
       raise 'OPENSTUDIO_EXE_PATH not set' unless ENV['OPENSTUDIO_EXE_PATH']
       raise "Unable to find file specified in OPENSTUDIO_EXE_PATH: `#{ENV['OPENSTUDIO_EXE_PATH']}`" unless File.exist?(ENV['OPENSTUDIO_EXE_PATH'])
       logger.info "Found ENV['OPENSTUDIO_EXE_PATH']"
       # set cmd from ENV variable
-      cmd = ENV['OPENSTUDIO_EXE_PATH'] + oscli_bundle(gemfile, gempath)
+      cmd = ENV['OPENSTUDIO_EXE_PATH'] + oscli_bundle(gemfile_dir)
       logger.info "Returning Oscli cmd: #{cmd}"
       cmd
     rescue Exception => e
@@ -34,7 +34,7 @@ module Utility
       else
         logger.error 'Unable to find Oscli.'
       end
-      logger.info "RESCUE: Returning Oscli cmd: #{cmd + oscli_bundle(gemfile, gempath)}"
+      logger.info "RESCUE: Returning Oscli cmd: #{cmd + oscli_bundle(gemfile_dir)}"
       cmd + oscli_bundle
     end
     
@@ -50,12 +50,12 @@ module Utility
       cmd
     end
 
-    # use bundle option only if we have a path to openstudio gemfile.
+    # use bundle option only if gemfile is set to true
     # if BUNDLE_PATH is not set (ie Docker), we must add these options
-    def self.oscli_bundle(gemfile, gemdir)
+    def self.oscli_bundle(gemfile_dir)
        bundle = ' --bundle '\
-      "#{gemfile} --bundle_path "\
-      "#{gemdir} --bundle_without native_ext"
+      "#{gemfile_dir}/Gemfile --bundle_path "\
+      "#{gemfile_dir}/gems --bundle_without native_ext"
     end
 
     # Set some env_vars from the running env var list, ignore the rest

--- a/server/app/models/analysis.rb
+++ b/server/app/models/analysis.rb
@@ -57,6 +57,7 @@ class Analysis
   field :download_zip, type: Boolean, default: true
   field :download_osm, type: Boolean, default: true
   field :download_osw, type: Boolean, default: true
+  field :gemfile, type: String, default: '' 
   field :download_reports, type: Boolean, default: true
   field :variable_display_name_choice, type: String, default: 'display_name'
 
@@ -505,7 +506,9 @@ class Analysis
       retry if extract_count < extract_max_count
       raise "Extraction of the seed.zip file failed #{extract_max_count} times with error #{e.message}"
     end
+     
     run_script_with_args 'initialize'
+    
   end
 
   # runs on web node

--- a/server/app/models/analysis.rb
+++ b/server/app/models/analysis.rb
@@ -57,7 +57,7 @@ class Analysis
   field :download_zip, type: Boolean, default: true
   field :download_osm, type: Boolean, default: true
   field :download_osw, type: Boolean, default: true
-  field :gemfile, type: String, default: '' 
+  field :gemfile, type: Boolean, default: false
   field :download_reports, type: Boolean, default: true
   field :variable_display_name_choice, type: String, default: 'display_name'
 


### PR DESCRIPTION
Related https://github.com/NREL/OpenStudio-PAT/pull/249

This PR attempts to simply the process of using ruby gems vs using an `initialization.sh` script that modifies the existing Gemfile on the worker nodes. The current way to run a workflow using custom gems looks something like this:

1 ) A user includes a worker initialization script (e.g https://github.com/NREL/OpenStudio-server/blob/develop/doc/initialization_scripts/set_gem_version.sh) that changes the contents of the existing Gemfile on the worker node (e.g. /opt/openstudio/server/Gemfile) with the desired gems.  Bundler then installs these gems to /opt/openstudio/server/gems

2 ) A datapoint runs on the worker node and uses these gems if this value is set - https://github.com/NREL/OpenStudio-server/blob/develop/server/config/environments/docker.rb#L113 

The call to openstudio looks like this: 
```
 /usr/local/bin/openstudio --bundle /var/oscli/Gemfile --bundle_path /var/oscli/gems --bundle_without native_ext
[17:28:33.853398 INFO] Running workflow using cmd /usr/local/bin/openstudio --bundle /var/oscli/Gemfile --bundle_path /var/oscli/gems --bundle_without native_ext --verbose run --workflow /mnt/openstudio/analysis_d1221dd3-1408-49f3-973c-a995d728e3f8/data_point_7da1065e-f289-4754-8bbe-de9d3db72c27/data_point.osw
```

This works reasonably well but there is an issue/bug when an analysis modifies the contents of the Gemfile, and then a new analysis inadvertently uses these custom gems as `config.os_gemfile_path = '/var/oscli'` is a global config setting.  The bundle args will be assembled into the openstudio command when it's not desired. 

The new proposed way is to allow a user to include a Gemfile within their analysis.zip and set simple boolean value in the osa.json file 

 `"gemfile": true,`  => use Gemfile included in the analysis.zip 
 `"gemfile": false,` => do not use custom gems and use embedded gems in openstudio (no bundler args). 

Also, bundler installs the gems into the analysis directory on the worker node to isolate gems between analysis runs.  The new command looks like this. 

```
/usr/local/bin/openstudio --bundle /mnt/openstudio/analysis_0f1bdd72-e58b-4e5b-af19-5c10e0254ad3/Gemfile --bundle_path /mnt/openstudio/analysis_0f1bdd72-e58b-4e5b-af19-5c10e0254ad3/gems --bundle_without native_ext
[17:48:32.495720 INFO] Running workflow using cmd /usr/local/bin/openstudio --bundle /mnt/openstudio/analysis_0f1bdd72-e58b-4e5b-af19-5c10e0254ad3/Gemfile --bundle_path /mnt/openstudio/analysis_0f1bdd72-e58b-4e5b-af19-5c10e0254ad3/gems --bundle_without native_ext --verbose run --workflow /mnt/openstudio/analysis_0f1bdd72-e58b-4e5b-af19-5c10e0254ad3/data_point_73e8056b-a4d4-44e7-a8c0-435e1c5204c9/data_point.osw 
```
The default setting is to not use custom gems. The only way to run a workload with gems is to include a Gemfile and set the attribute to true. A gemfile can include just the gems that you want to add/change in OpenStudio (e.g. below) so this should be make things easier. 


```
 source 'http://rubygems.org'
 ruby '~>2.7.0'
 
 gem 'openstudio-standards', '= 0.2.16'
```
























2 ) When an anals
