### PR TITLE
Web pages update

### DIFF
--- a/server/app/controllers/analyses_controller.rb
+++ b/server/app/controllers/analyses_controller.rb
@@ -35,7 +35,7 @@ class AnalysesController < ApplicationController
   def show
     logger.debug "analyses_controller.show enter"
     # for pagination
-    per_page = 50
+    per_page = 200
 
     @analysis = Analysis.find(params[:id])
 

--- a/server/app/controllers/pages_controller.rb
+++ b/server/app/controllers/pages_controller.rb
@@ -58,7 +58,7 @@ class PagesController < ApplicationController
     unless @current.nil?
       # aggregate results of current analysis
       aggregated_results = DataPoint.collection.aggregate(
-        [{ '$match' => { 'analysis_id' => @current.id } }, { '$group' => { '_id' => { 'analysis_id' => '$analysis_id', 'status' => '$status' }, count: { '$sum' => 1 } } }], :allow_disk_use => true
+        [{ '$match' => { 'analysis_id' => @current.id } }, { '$group' => { '_id' => { 'analysis_id' => '$analysis_id', 'status' => '$status', 'status_message' => '$status_message' }, count: { '$sum' => 1 } } }, { '$sort' => { '_id.status' => 1 } }], :allow_disk_use => true
       )
     end
     # for js
@@ -70,7 +70,9 @@ class PagesController < ApplicationController
       aggregated_results.each do |res|
         # this is the format D3 wants the data in
         rec = {}
-        rec['label'] = res['_id']['status']
+        rec['label'] = res['_id']['status'] + ' ' + res['_id']
+        rec['label'].gsub!('completed completed', 'completed')
+        rec['label'] = rec['label'].rstrip
         rec['value'] = res['count']
         cnt += res['count'].to_i
         @js_res << rec

--- a/server/app/controllers/pages_controller.rb
+++ b/server/app/controllers/pages_controller.rb
@@ -63,8 +63,10 @@ class PagesController < ApplicationController
     end
     # for js
     cnt = 0
+    complete = 0
     @js_res = []
     @total = 0
+    @percent_complete = 0
 
     unless @current.nil?
       aggregated_results.each do |res|
@@ -74,11 +76,15 @@ class PagesController < ApplicationController
         rec['label'].gsub!('completed completed', 'completed')
         rec['label'] = rec['label'].rstrip
         rec['value'] = res['count']
-        cnt += res['count'].to_i
         @js_res << rec
+        if res['_id']['status'] == 'completed' 
+          complete += res['count'].to_i
+        end
+        cnt += res['count'].to_i
       end
 
       @total = cnt
+      @percent_complete = 100.0 * complete / cnt
     end
   end
 end

--- a/server/app/controllers/pages_controller.rb
+++ b/server/app/controllers/pages_controller.rb
@@ -70,7 +70,7 @@ class PagesController < ApplicationController
       aggregated_results.each do |res|
         # this is the format D3 wants the data in
         rec = {}
-        rec['label'] = res['_id']['status'] + ' ' + res['_id']
+        rec['label'] = res['_id']['status'] + ' ' + res['_id']['status_message']
         rec['label'].gsub!('completed completed', 'completed')
         rec['label'] = rec['label'].rstrip
         rec['value'] = res['count']

--- a/server/app/lib/analysis_library/baseline_perturbation.rb
+++ b/server/app/lib/analysis_library/baseline_perturbation.rb
@@ -134,7 +134,7 @@ class AnalysisLibrary::BaselinePerturbation < AnalysisLibrary::Base
               instance[var.id.to_s.to_sym] = var.static_value unless meas_var.include? var.id
             end
             # logger.info "instance: #{instance}"
-            #sleep 1
+            sleep 1
             samples << instance
           end
         end

--- a/server/app/lib/analysis_library/baseline_perturbation.rb
+++ b/server/app/lib/analysis_library/baseline_perturbation.rb
@@ -134,7 +134,7 @@ class AnalysisLibrary::BaselinePerturbation < AnalysisLibrary::Base
               instance[var.id.to_s.to_sym] = var.static_value unless meas_var.include? var.id
             end
             # logger.info "instance: #{instance}"
-            sleep 1
+            #sleep 1
             samples << instance
           end
         end

--- a/server/app/views/analyses/show.js.erb
+++ b/server/app/views/analyses/show.js.erb
@@ -4,5 +4,13 @@
 */
 
 $("#<%= @status %>simulations").html('
-<%= escape_javascript render(:partial => "analyses/table", :locals => { users: @status_simulations, status: @status, :all_page => @all_page, :completed_page => @completed_page, :running_page => @running_page, :queued_page => @queued_page, :na_page => @na_page, :page => params[:page] }) %>
+<%= escape_javascript render(:partial => "analyses/table", 
+                             :locals => { users: @status_simulations, 
+                                          status: @status, 
+                                          :all_page => @all_page, 
+                                          :completed_page => @completed_page, 
+                                          :running_page => @running_page, 
+                                          :queued_page => @queued_page, 
+                                          :na_page => @na_page, 
+                                          :page => params[:page] }) %>
 ');

--- a/server/app/views/pages/dashboard.html.erb
+++ b/server/app/views/pages/dashboard.html.erb
@@ -50,12 +50,12 @@
             <p>
               <% if not @current.end_time.nil? %>
                 End: <%= @current.end_time.strftime("%m/%d/%Y %H:%M:%S") %>
-              <% elif @completed_perc > 10 %>
+              <% elsif @completed_perc > 10 %>
                 <% etf = Time.at((Time.now-@current.start_time)/(@completed_perc/100.0)) %>
                 Estimated time to completion (H:M): <%= etf.strftime("%H:%M") %>
                 </p><p>Current time: <%= Time.now.strftime("%m/%d/%Y %H:%M:%S") %>
               <% else %>
-                Estimated time to completion (H:M): ...calculating... %>
+                Estimated time to completion (H:M): ...calculating...
                 </p><p>Current time: <%= Time.now.strftime("%m/%d/%Y %H:%M:%S") %>
               <% end %>
             </p>

--- a/server/app/views/pages/dashboard.html.erb
+++ b/server/app/views/pages/dashboard.html.erb
@@ -47,7 +47,18 @@
               <% unless @current.start_time.nil? %><%= @current.start_time.strftime("%m/%d/%Y %H:%M:%S") %>
               <% end %>
             </p>
-            <p><% unless @current.end_time.nil? %>End: <%= @current.end_time.strftime("%m/%d/%Y %H:%M:%S") %><% end %></p>
+            <p>
+              <% if not @current.end_time.nil? %>
+                End: <%= @current.end_time.strftime("%m/%d/%Y %H:%M:%S") %>
+              <% elif @completed_perc > 10 %>
+                <% etf = Time.at((Time.now-@current.start_time)/(@completed_perc/100.0)) %>
+                Estimated time to completion (H:M): <%= etf.strftime("%H:%M") %>
+                </p><p>Current time: <%= Time.now.strftime("%m/%d/%Y %H:%M:%S") %>
+              <% else %>
+                Estimated time to completion (H:M): ...calculating... %>
+                </p><p>Current time: <%= Time.now.strftime("%m/%d/%Y %H:%M:%S") %>
+              <% end %>
+            </p>
             <p><% unless @current.end_time.nil? || @current.start_time.nil? %>Duration:  <%= distance_of_time_in_words(@current.start_time, @current.end_time) %> <% end %></p>
             <p>Status: <span class="label <% if @current.status == 'completed' %>label-success<% end %>"><%=@current.status %></span></p>
             <p><span class="badge badge-info"><%= @current.data_points.count %></span> Datapoints</p>
@@ -139,11 +150,14 @@
 
   <script type="text/javascript">
       function make_pie_chart(data, cnt) {
-          var w = 230,                        //width
-                  h = 230,                            //height
-                  r = 110,                            //radius
-                  radius = 115,                          //to center on svg
-                  color = d3.scale.category20();     //builtin range of colors
+          var w = 230,                //width
+              h = 230,                //height
+              r = 110,                //radius
+          radius = 115,               //to center on svg
+          defaultColor = "#333333",   //default color for values not in domain
+          color = d3.scale.ordinal()     //builtin range of colors
+          .domain(["completed normal", "completed datapoint failure", "started", "queued", "na"]) //all possible labels
+          .range(["#5cb85c", "#f0ad4e", "#ebccd1", "#5bc0de", "#428bca"]); //colors
 
           var vis = d3.select("#pie")
                   .append("svg:svg")              //create the SVG element inside the <body>
@@ -169,7 +183,7 @@
 
           arcs.append("svg:path")
                   .attr("fill", function (d, i) {
-                      return color(i);
+                      return color(d.data.label) || defaultColor;
                   }) //set the color for each slice to be chosen from the color function defined above
                   .attr("d", arc);                                    //this creates the actual SVG path using the associated data (pie) with the arc drawing function
 
@@ -188,7 +202,7 @@
                   .attr("width", w)
                   .attr("height", 100)
                   .selectAll("g")
-                  .data(color.domain().slice())
+                  .data(data)
                   .enter().append("g")
                   .attr("transform", function (d, i) {
                       return "translate(10," + (i * 20 + 20) + ")";
@@ -197,14 +211,16 @@
           legend.append("rect")
                   .attr("width", 18)
                   .attr("height", 18)
-                  .style("fill", color);
+          .style("fill", function (d) {
+                     return color(d.label);
+                    });
 
           legend.append("text")
                   .attr("x", 24)
                   .attr("y", 9)
                   .attr("dy", ".35em")
-                  .text(function (d, i) {
-                      return data[i].label + " (" + data[i].value + ")";
+                  .text(function (d) {
+                      return d.label + " (" + d.value + ")";
                   });
 
           var total = d3.select("#pie").append("svg")

--- a/server/app/views/pages/dashboard.html.erb
+++ b/server/app/views/pages/dashboard.html.erb
@@ -7,8 +7,8 @@
 
 <!-- vars for javascript -->
 <%= javascript_tag do %>
-    statuses = <%= raw @js_res.to_json %>;
-    total = <%= raw @total.to_json %>;
+    const statuses = <%= raw @js_res.to_json %>;
+    const total = <%= raw @total.to_json %>;
 <% end %>
 
 <div class="row-fluid gray-header">
@@ -50,8 +50,8 @@
             <p>
               <% if not @current.end_time.nil? %>
                 End: <%= @current.end_time.strftime("%m/%d/%Y %H:%M:%S") %>
-              <% elsif @completed_perc > 10 %>  *** This needs to be fixed to be the current analysis.
-                <% etf = Time.at((Time.now-@current.start_time)/(@completed_perc/100.0)) %>
+              <% elsif @percent_complete > 10 %>
+                <% etf = Time.at((Time.now-@current.start_time)/(@percent_complete/100.0)) %>
                 Estimated time to completion (H:M): <%= etf.strftime("%H:%M") %>
                 </p><p>Current time: <%= Time.now.strftime("%m/%d/%Y %H:%M:%S") %>
               <% else %>

--- a/server/app/views/pages/dashboard.html.erb
+++ b/server/app/views/pages/dashboard.html.erb
@@ -50,7 +50,7 @@
             <p>
               <% if not @current.end_time.nil? %>
                 End: <%= @current.end_time.strftime("%m/%d/%Y %H:%M:%S") %>
-              <% elsif @completed_perc > 10 %>
+              <% elsif @completed_perc > 10 %>  *** This needs to be fixed to be the current analysis.
                 <% etf = Time.at((Time.now-@current.start_time)/(@completed_perc/100.0)) %>
                 Estimated time to completion (H:M): <%= etf.strftime("%H:%M") %>
                 </p><p>Current time: <%= Time.now.strftime("%m/%d/%Y %H:%M:%S") %>
@@ -157,7 +157,7 @@
           defaultColor = "#333333",   //default color for values not in domain
           color = d3.scale.ordinal()     //builtin range of colors
           .domain(["completed normal", "completed datapoint failure", "started", "queued", "na"]) //all possible labels
-          .range(["#5cb85c", "#f0ad4e", "#ebccd1", "#5bc0de", "#428bca"]); //colors
+          .range (["#449d44",          "#d9534f",                     "#ec971f", "#428bca", "#5bc0de"]); //colors
 
           var vis = d3.select("#pie")
                   .append("svg:svg")              //create the SVG element inside the <body>

--- a/server/config/initializers/kaminari_config.rb
+++ b/server/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 200
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
Updates to the web interface:

- The pagination was not working properly as the Kaminari gem defaults to 25 entries per page and the display was set to 50. Added the gem config file and set to 200 entries per page.
- For the pie chart sorted the datapoints and added differentiation between successful simulations and failures; linked the cases to specific colors (picked from the css). This ensures that the pie chart display is consistent.
- Added logic to estimate the time remaining for the analysis. It does not display the estimate until at least 10% of the datapoints are complete.
- Added 'const' declaration to the JavaScript variables in dashboard (suggested by our code checker).
- Some minor updates to code layout in the files (tabs/spaces/carriage returns) to improve readability.