### PR TITLE
Add webrick to server gemfile

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -7,6 +7,7 @@ ruby '~>3.2.0'
 # gem 'rubygems-update', '2.7.8'
 
 gem 'rails', '~> 6.1.3'
+gem 'webrick', '~> 1.8.2'
 gem 'rake', '~> 13.0'
 
 # added for support of the project rakefile


### PR DESCRIPTION
The current behavior of a server launch, with a clean install of Ruby 3, is a fail.

```
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
Could not find server "". 
Run `bin/rails server --help` for more options.
```

The reason is webrick is not included in Ruby since 3.0.0 : https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/