### PR TITLE
Local Server startup enhancement

### DIFF
--- a/bin/openstudio_meta
+++ b/bin/openstudio_meta
@@ -523,6 +523,16 @@ class StartLocal
       FileUtils.mkdir_p "#{project_dir}/logs" unless Dir.exist? "#{project_dir}/logs"
     end
 
+    # ─────── log rotation ───────
+    logs_dir = File.join(project_dir, 'logs')
+    dj_log   = File.join(logs_dir, 'delayed_job.log')
+    if File.exist?(dj_log)
+      ts = Time.now.strftime('%Y%m%d%H%M%S')
+      FileUtils.mv(dj_log, "#{dj_log}.#{ts}")
+      $logger.debug "Rotated existing delayed_job.log to delayed_job.log.#{ts}"
+      puts "Rotated existing delayed_job.log to delayed_job.log.#{ts}"
+    end
+
     if options[:energyplus_exe_path] && ::File.exist?(options[:energyplus_exe_path])
       ::ENV['ENERGYPLUS_EXE_PATH'] = options[:energyplus_exe_path]
     end

--- a/bin/resources/local.rb
+++ b/bin/resources/local.rb
@@ -387,7 +387,6 @@ def start_local_server(project_directory, mongo_directory, ruby_path, worker_num
     end
 
     $logger.debug "delayed_job.worker_#{ind} is up!"
-end
   end
 
   find_windows_pids(state_file) if Gem.win_platform?

--- a/bin/resources/local.rb
+++ b/bin/resources/local.rb
@@ -35,6 +35,21 @@ def is_port_open?(port)
   false
 end
 
+# Blocks until `regex` appears in the given log file, or times out.
+# Returns true if seen, false if timeout.
+def wait_for_log_pattern(log_path, regex, timeout_secs = 15)
+  deadline = Time.now + timeout_secs
+  until Time.now > deadline
+    if File.exist?(log_path)
+      File.foreach(log_path) do |line|
+        return true if line =~ regex
+      end
+    end
+    sleep 0.1
+  end
+  false
+end
+
 # Find the first available port within range
 #
 # @param starting [Integer] port to start search from
@@ -324,7 +339,7 @@ def start_local_server(project_directory, mongo_directory, ruby_path, worker_num
   $logger.debug 'RAILS STARTED'
 
   begin
-    ::Timeout.timeout(15) do
+    ::Timeout.timeout(60) do
       success = system(dj_server_command)
       unless success
         $logger.error "dj_server returned non-zero status code `#{$?.exitstatus}`. Please refer to "\
@@ -338,11 +353,17 @@ def start_local_server(project_directory, mongo_directory, ruby_path, worker_num
     kill_processes(state_file)
     exit 1
   end
-  $logger.debug 'DELAYED JOBS SERVER MAY HAVE BEEN STARTED'
+  # now wait until the server process actually forks and prints “Starting job worker”
+  server_log = File.join(project_directory, 'logs', 'delayed_job.log')
+  unless wait_for_log_pattern(server_log, /\[Worker\(delayed_job\.server\b.*\] Starting job worker/, 30)
+    $logger.error "Timed out waiting for delayed_job.server to start. See #{server_log}"
+    kill_processes(state_file); exit 1
+  end
+  $logger.debug 'delayed_job.server is up!'
 
   dj_worker_commands.each_with_index do |cmd, ind|
     begin
-      ::Timeout.timeout(15) do
+      ::Timeout.timeout(60) do
         success = system(cmd)
         unless success
           $logger.error "dj_worker_#{ind} returned non-zero status code `#{$?.exitstatus}`. Please refer to "\
@@ -357,8 +378,16 @@ def start_local_server(project_directory, mongo_directory, ruby_path, worker_num
       kill_processes(state_file)
       exit 1
     end
-    $logger.debug "DELAYED JOBS WORKER #{ind} MAY HAVE BEEN STARTED"
-    sleep 20 # TODO: Figure out how to determine if dj instance is initialized.
+    # wait for that worker to actually come up
+    worker_log = File.join(project_directory, 'logs', 'delayed_job.log')
+    pattern    = /\[Worker\(delayed_job\.worker_#{ind}\b.*\] Starting job worker/
+    unless wait_for_log_pattern(worker_log, pattern, 15)
+      $logger.error "Timed out waiting for delayed_job.worker_#{ind} to start. See #{worker_log}"
+      kill_processes(state_file); exit 1
+    end
+
+    $logger.debug "delayed_job.worker_#{ind} is up!"
+end
   end
 
   find_windows_pids(state_file) if Gem.win_platform?

--- a/bin/resources/local.rb
+++ b/bin/resources/local.rb
@@ -362,31 +362,31 @@ def start_local_server(project_directory, mongo_directory, ruby_path, worker_num
   $logger.debug 'delayed_job.server is up!'
 
   dj_worker_commands.each_with_index do |cmd, ind|
+    worker_id = ind + 1
     begin
       ::Timeout.timeout(60) do
         success = system(cmd)
         unless success
-          $logger.error "dj_worker_#{ind} returned non-zero status code `#{$?.exitstatus}`. Please refer to "\
-          "`#{::File.join(project_directory, 'logs', 'dj_worker_' + ind + '.log')}`."
+          $logger.error "dj_worker_#{worker_id} returned non-zero status code `#{$?.exitstatus}`. Please refer to "\
+          "`#{::File.join(project_directory, 'logs', 'dj_worker_' + worker_id + '.log')}`."
           kill_processes(state_file)
           exit 1
         end
       end
     rescue ::Timeout::Error
-      $logger.error "dj_worker_#{ind} failed to launch. Please refer to `#{::File.join(project_directory, 'logs',
-                                                                                       'dj_worker_' + ind.to_s + '.log')}`."
+      $logger.error "dj_worker_#{worker_id} failed to launch. Please refer to `#{::File.join(project_directory, 'logs', 'dj_worker_' + worker_id.to_s + '.log')}`."
       kill_processes(state_file)
       exit 1
     end
     # wait for that worker to actually come up
     worker_log = File.join(project_directory, 'logs', 'delayed_job.log')
-    pattern    = /\[Worker\(delayed_job\.worker_#{ind}\b.*\] Starting job worker/
-    unless wait_for_log_pattern(worker_log, pattern, 15)
-      $logger.error "Timed out waiting for delayed_job.worker_#{ind} to start. See #{worker_log}"
+    pattern    = /\[Worker\(delayed_job\.worker_#{worker_id}\b.*\] Starting job worker/
+    unless wait_for_log_pattern(worker_log, pattern, 60)
+      $logger.error "Timed out waiting for delayed_job.worker_#{worker_id} to start. See #{worker_log}"
       kill_processes(state_file); exit 1
     end
 
-    $logger.debug "delayed_job.worker_#{ind} is up!"
+    $logger.debug "delayed_job.worker_#{worker_id} is up!"
   end
 
   find_windows_pids(state_file) if Gem.win_platform?


### PR DESCRIPTION
https://github.com/NREL/OpenStudio-server/issues/826

instead of a 15s wait time, followed by a 20 second sleep in the worker startup loop, 
rotate the delayed_job.log on startup, then in it check for the strings: `worker_N` and `Starting Job worker` in these lines:
`delayed_job.worker_N host:xxxx pid:xxxx)] Starting job worker`
which occur once the `bin/delayed_job` has been `daemonized`

bump the timeout around the system call to 60 to give it more time to launch, but save time by checking the log file for the startup notice.