### PR TITLE
Add GitHub Actions workflow for building installers

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -67,6 +67,25 @@ jobs:
           name: openstudio-server-gems-darwin
           path: build/NREL/export/*.tar.gz
 
+  build-macos-arm:
+    runs-on: macos-15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup
+        shell: bash
+        run: ./ci/github-actions/setup.sh
+        env:
+          BUILD_TYPE: build
+      - name: Build Gem Package
+        shell: bash
+        run: ./ci/github-actions/export_build_osx.sh
+      - name: Upload macOS ARM Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openstudio-server-gems-darwin-arm
+          path: build/NREL/export/*.tar.gz
+
   build-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -49,7 +49,7 @@ jobs:
           path: build/NREL/export/*.tar.gz
 
   build-macos:
-    runs-on: macos-15-intel # Matching the test workflow
+    runs-on: macos-15-intel # Intel runner required for x86_64 architecture compatibility with OpenStudio (matching the test workflow)
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -1,0 +1,124 @@
+name: Build Installers
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - develop
+      - '3.11.0'
+  pull_request:
+
+env:
+  OPENSTUDIO_VERSION: 3.11.0
+  OPENSTUDIO_VERSION_SHA: 241b8abb4d
+  OPENSTUDIO_VERSION_EXT: ""
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup
+        shell: bash
+        run: ./ci/github-actions/setup.sh
+        env:
+          BUILD_TYPE: build
+      - name: Build Gem Package
+        shell: bash
+        run: ./ci/github-actions/export_build_linux.sh
+      - name: Upload Linux Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openstudio-server-gems-linux
+          path: build/NREL/export/*.tar.gz
+
+  build-macos:
+    runs-on: macos-15-intel # Matching the test workflow
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup
+        shell: bash
+        run: ./ci/github-actions/setup.sh
+        env:
+          BUILD_TYPE: build
+      - name: Build Gem Package
+        shell: bash
+        run: ./ci/github-actions/export_build_osx.sh
+      - name: Upload macOS Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openstudio-server-gems-darwin
+          path: build/NREL/export/*.tar.gz
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: false # We manage gems manually via openstudio_meta
+
+      - name: Download and Install OpenStudio
+        shell: powershell
+        run: |
+          $Version = "${{ env.OPENSTUDIO_VERSION }}"
+          $Ext = "${{ env.OPENSTUDIO_VERSION_EXT }}"
+          $Sha = "${{ env.OPENSTUDIO_VERSION_SHA }}"
+          $InstallerName = "OpenStudio-$Version$Ext+$Sha-Windows.exe"
+          $Url = "https://github.com/NREL/OpenStudio/releases/download/v$Version$Ext/$InstallerName"
+          
+          Write-Host "Downloading $Url..."
+          Invoke-WebRequest -Uri $Url -OutFile $InstallerName
+          
+          Write-Host "Installing OpenStudio..."
+          Start-Process -FilePath ".\$InstallerName" -ArgumentList "/S /D=C:\projects\openstudio" -Wait
+          
+          # Verify
+          $env:Path = "C:\projects\openstudio\bin;$env:Path"
+          openstudio openstudio_version
+
+      - name: Setup MSYS2 and Dependencies
+        shell: cmd
+        run: |
+          ridk install 2 3
+          
+          REM Mimic setup.cmd gcc installation if needed, but standard ruby setup usually suffices.
+          REM Checking gcc version
+          gcc --version
+
+      - name: Build Gem Package
+        shell: cmd
+        env:
+          BUNDLE_VERSION: 2.4.10
+          GEM_HOME: C:\projects\openstudio-server\gems
+          GEM_PATH: C:\projects\openstudio-server\gems;C:\projects\openstudio-server\gems\bundler\gems
+          RUBYLIB: C:\projects\openstudio\Ruby
+          OPENSTUDIO_TEST_EXE: C:\projects\openstudio\bin\openstudio.exe
+        run: |
+          REM Create export directory
+          mkdir C:\export
+          
+          REM Install Bundler
+          gem install bundler -v %BUNDLE_VERSION% --no-document
+          
+          REM Run Build
+          ruby bin\openstudio_meta install_gems --export="C:\export" --debug
+          
+          REM Move export to workspace for upload
+          mkdir build\NREL
+          move C:\export build\NREL\export
+
+      - name: Upload Windows Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openstudio-server-gems-win32
+          path: build/NREL/export/*.tar.gz

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -98,33 +98,9 @@ jobs:
           ruby-version: '3.2.2'
           bundler-cache: false # We manage gems manually via openstudio_meta
 
-      - name: Download and Install OpenStudio
-        shell: powershell
-        run: |
-          $Version = "${{ env.OPENSTUDIO_VERSION }}"
-          $Ext = "${{ env.OPENSTUDIO_VERSION_EXT }}"
-          $Sha = "${{ env.OPENSTUDIO_VERSION_SHA }}"
-          $InstallerName = "OpenStudio-$Version$Ext+$Sha-Windows.exe"
-          $Url = "https://github.com/NREL/OpenStudio/releases/download/v$Version$Ext/$InstallerName"
-          
-          Write-Host "Downloading $Url..."
-          Invoke-WebRequest -Uri $Url -OutFile $InstallerName
-          
-          Write-Host "Installing OpenStudio..."
-          Start-Process -FilePath ".\$InstallerName" -ArgumentList "/S /D=C:\projects\openstudio" -Wait
-          
-          # Verify
-          $env:Path = "C:\projects\openstudio\bin;$env:Path"
-          openstudio openstudio_version
-
-      - name: Setup MSYS2 and Dependencies
+      - name: Setup Windows Environment
         shell: cmd
-        run: |
-          ridk install 2 3
-          
-          REM Mimic setup.cmd gcc installation if needed, but standard ruby setup usually suffices.
-          REM Checking gcc version
-          gcc --version
+        run: ci\github-actions\setup_win.bat
 
       - name: Build Gem Package
         shell: cmd
@@ -134,19 +110,7 @@ jobs:
           GEM_PATH: C:\projects\openstudio-server\gems;C:\projects\openstudio-server\gems\bundler\gems
           RUBYLIB: C:\projects\openstudio\Ruby
           OPENSTUDIO_TEST_EXE: C:\projects\openstudio\bin\openstudio.exe
-        run: |
-          REM Create export directory
-          mkdir C:\export
-          
-          REM Install Bundler
-          gem install bundler -v %BUNDLE_VERSION% --no-document
-          
-          REM Run Build
-          ruby bin\openstudio_meta install_gems --export="C:\export" --debug
-          
-          REM Move export to workspace for upload
-          mkdir build\NREL
-          move C:\export build\NREL\export
+        run: ci\github-actions\export_build_win.bat
 
       - name: Upload Windows Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -2,17 +2,29 @@ name: Build Installers
 
 on:
   workflow_dispatch:
+    inputs:
+      openstudio_version:
+        description: 'OpenStudio Version (e.g. 3.11.0)'
+        required: true
+        default: '3.11.0'
+      openstudio_version_sha:
+        description: 'OpenStudio Version SHA (e.g. 241b8abb4d)'
+        required: true
+        default: '241b8abb4d'
+      openstudio_version_ext:
+        description: 'OpenStudio Version Extension (e.g. -rc1)'
+        required: false
+        default: ''
   push:
     branches:
       - master
       - develop
-      - '3.11.0'
   pull_request:
 
 env:
-  OPENSTUDIO_VERSION: 3.11.0
-  OPENSTUDIO_VERSION_SHA: 241b8abb4d
-  OPENSTUDIO_VERSION_EXT: ""
+  OPENSTUDIO_VERSION: ${{ inputs.openstudio_version || '3.11.0' }}
+  OPENSTUDIO_VERSION_SHA: ${{ inputs.openstudio_version_sha || '241b8abb4d' }}
+  OPENSTUDIO_VERSION_EXT: ${{ inputs.openstudio_version_ext || '' }}
 
 jobs:
   build-linux:

--- a/bin/openstudio_meta
+++ b/bin/openstudio_meta
@@ -334,9 +334,11 @@ class InstallGems
       sys_cmds << "#{$ruby_path} #{bundler_bin} config build.libxml-ruby --use-system-libraries --with-xml2-config=/usr/bin/xml2-config"
     end
     if options[:test_dev_build]
-      sys_cmds << "#{$ruby_path} #{bundler_bin} install --retry=3 --jobs=1 --with default development test"
+      sys_cmds << "#{$ruby_path} #{bundler_bin} config set --local with 'default development test'"
+      sys_cmds << "#{$ruby_path} #{bundler_bin} install --retry=3 --jobs=1"
     else
-      sys_cmds << "#{$ruby_path} #{bundler_bin} install --retry=3 --jobs=1 --without development test"
+      sys_cmds << "#{$ruby_path} #{bundler_bin} config set --local without 'development test'"
+      sys_cmds << "#{$ruby_path} #{bundler_bin} install --retry=3 --jobs=1"
     end
     sys_cmds << "#{$ruby_path} #{bundler_bin} update"
     #unless Gem.win_platform?

--- a/ci/github-actions/export_build_win.bat
+++ b/ci/github-actions/export_build_win.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+REM Create export directory
+if not exist "C:\export" mkdir C:\export
+
+REM Install Bundler
+call gem install bundler -v %BUNDLE_VERSION% --no-document
+if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+REM Run Build
+call ruby bin\openstudio_meta install_gems --export="C:\export" --debug
+if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+REM Move export to workspace for upload
+if not exist "build\NREL" mkdir build\NREL
+move C:\export build\NREL\export
+if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+
+endlocal

--- a/ci/github-actions/setup_win.bat
+++ b/ci/github-actions/setup_win.bat
@@ -1,0 +1,39 @@
+@echo off
+setlocal
+
+REM --- Install OpenStudio ---
+set "InstallerName=OpenStudio-%OPENSTUDIO_VERSION%%OPENSTUDIO_VERSION_EXT%+%OPENSTUDIO_VERSION_SHA%-Windows.exe"
+set "Url=https://github.com/NREL/OpenStudio/releases/download/v%OPENSTUDIO_VERSION%%OPENSTUDIO_VERSION_EXT%/%InstallerName%"
+
+echo Downloading %Url%...
+powershell -Command "Invoke-WebRequest -Uri '%Url%' -OutFile '%InstallerName%'"
+if %ERRORLEVEL% neq 0 (
+    echo Error downloading OpenStudio
+    exit /b %ERRORLEVEL%
+)
+
+echo Installing OpenStudio...
+start /wait "" ".\%InstallerName%" /S /D=C:\projects\openstudio
+if %ERRORLEVEL% neq 0 (
+    echo Error installing OpenStudio
+    exit /b %ERRORLEVEL%
+)
+
+REM Verify OpenStudio
+set "PATH=C:\projects\openstudio\bin;%PATH%"
+call openstudio openstudio_version
+if %ERRORLEVEL% neq 0 (
+    echo Error verifying OpenStudio
+    exit /b %ERRORLEVEL%
+)
+
+REM --- Setup MSYS2 and Dependencies ---
+call ridk install 2 3
+if %ERRORLEVEL% neq 0 (
+    echo Error running ridk install
+    exit /b %ERRORLEVEL%
+)
+
+call gcc --version
+
+endlocal

--- a/ci/github-actions/setup_win.bat
+++ b/ci/github-actions/setup_win.bat
@@ -8,14 +8,14 @@ set "Url=https://github.com/NREL/OpenStudio/releases/download/v%OPENSTUDIO_VERSI
 echo Downloading %Url%...
 powershell -Command "Invoke-WebRequest -Uri '%Url%' -OutFile '%InstallerName%'"
 if %ERRORLEVEL% neq 0 (
-    echo Error downloading OpenStudio
+    echo Failed to download OpenStudio from %Url% (exit code %ERRORLEVEL%)
     exit /b %ERRORLEVEL%
 )
 
 echo Installing OpenStudio...
 start /wait "" ".\%InstallerName%" /S /D=C:\projects\openstudio
 if %ERRORLEVEL% neq 0 (
-    echo Error installing OpenStudio
+    echo Failed to install OpenStudio from "%InstallerName%" (exit code %ERRORLEVEL%)
     exit /b %ERRORLEVEL%
 )
 
@@ -23,17 +23,21 @@ REM Verify OpenStudio
 set "PATH=C:\projects\openstudio\bin;%PATH%"
 call openstudio openstudio_version
 if %ERRORLEVEL% neq 0 (
-    echo Error verifying OpenStudio
+    echo Failed to verify OpenStudio installation - 'openstudio openstudio_version' command failed (exit code %ERRORLEVEL%)
     exit /b %ERRORLEVEL%
 )
 
 REM --- Setup MSYS2 and Dependencies ---
 call ridk install 2 3
 if %ERRORLEVEL% neq 0 (
-    echo Error running ridk install
+    echo Failed to install MSYS2 dependencies via ridk (exit code %ERRORLEVEL%)
     exit /b %ERRORLEVEL%
 )
 
 call gcc --version
+if %ERRORLEVEL% neq 0 (
+    echo Error: gcc not found
+    exit /b %ERRORLEVEL%
+)
 
 endlocal

--- a/docker/deployment/scripts/deploy_docker_github_actions.sh
+++ b/docker/deployment/scripts/deploy_docker_github_actions.sh
@@ -15,7 +15,7 @@ elif [ "${GITHUB_REF}" == "refs/heads/master" ]; then
 elif [ "${GITHUB_REF}" == "refs/heads/setup_github_actions" ]; then
     IMAGETAG=experimental
 elif [ "${GITHUB_REF}" == "refs/heads/3.11.0" ]; then
-     IMAGETAG="3.11.0-rc2"
+     IMAGETAG="3.11.0"
 fi
 
 if [ "${IMAGETAG}" != "skip" ]; then


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automate the building of platform-specific installers for OpenStudio. The workflow includes manual inputs for versioning, enhances error messaging, and refactors the Windows build process to utilize batch scripts. Additionally, it adds support for macOS ARM builds. Modern bundler configuration syntax is now used in the openstudio_meta updates.