### PR TITLE
Limit size of simulation log file to prevent BSON size error

### DIFF
--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -636,6 +636,7 @@ module DjJobs
 
       log_size = File.size(log_path)
       lines = []
+      truncated_by_lines = false
 
       File.open(log_path, 'rb') do |file|
         if log_size > MAX_INLINE_SDP_LOG_BYTES
@@ -643,12 +644,20 @@ module DjJobs
           file.gets
         end
 
-        lines = file.readlines.last(MAX_INLINE_SDP_LOG_LINES)
+        all_lines = file.readlines
+        truncated_by_lines = all_lines.length > MAX_INLINE_SDP_LOG_LINES
+        lines = all_lines.last(MAX_INLINE_SDP_LOG_LINES).map do |line|
+          line.encode('UTF-8', invalid: :replace, undef: :replace, replace: "\uFFFD")
+        end
       end
 
-      if log_size > MAX_INLINE_SDP_LOG_BYTES
-        omitted_bytes = log_size - MAX_INLINE_SDP_LOG_BYTES
-        lines.unshift("[OpenStudio Server truncated the inline datapoint log by #{omitted_bytes} bytes. Download the Datapoint Simulation Log result file for the full output.]\n")
+      truncated_by_bytes = log_size > MAX_INLINE_SDP_LOG_BYTES
+      if truncated_by_bytes || truncated_by_lines
+        note = "[OpenStudio Server truncated the inline datapoint log"
+        note += " to the last #{MAX_INLINE_SDP_LOG_BYTES} bytes" if truncated_by_bytes
+        note += " and #{MAX_INLINE_SDP_LOG_LINES} lines" if truncated_by_lines
+        note += ". Download the Datapoint Simulation Log result file for the full output.]\n"
+        lines.unshift(note)
       end
 
       lines

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -632,7 +632,7 @@ module DjJobs
     end
 
     def inline_log_lines(log_path)
-      return [] unless File.exist?(log_path)
+      return [] if log_path.nil? || !File.exist?(log_path)
 
       log_size = File.size(log_path)
       lines = []

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -259,7 +259,7 @@ module DjJobs
           if File.exist?(run_log_file)
             @sim_logger.info "Setting sdp_log_file to #{run_log_file} which exists? #{File.exist?(run_log_file)}"
             @data_point.sdp_log_file = inline_log_lines(run_log_file)
-          elsif File.exist?(process_log)
+          elsif process_log && File.exist?(process_log)
             @sim_logger.info "Setting sdp_log_file to #{process_log} which exists? #{File.exist?(process_log)}"
             @data_point.sdp_log_file = inline_log_lines(process_log)
           end

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -11,6 +11,9 @@ module DjJobs
     require 'date'
     require 'json'
 
+    MAX_INLINE_SDP_LOG_BYTES = 5_000_000
+    MAX_INLINE_SDP_LOG_LINES = 5_000
+
     def initialize(data_point_id, options = {})
       @data_point = DataPoint.find(data_point_id)
       @options = options
@@ -255,10 +258,10 @@ module DjJobs
           #set sdp_log_file to run/run.log if it exists, else try and set to oscli_simulation.log
           if File.exist?(run_log_file)
             @sim_logger.info "Setting sdp_log_file to #{run_log_file} which exists? #{File.exist?(run_log_file)}"
-            @data_point.sdp_log_file = File.read(run_log_file).lines if File.exist? run_log_file
+            @data_point.sdp_log_file = inline_log_lines(run_log_file)
           elsif File.exist?(process_log)
             @sim_logger.info "Setting sdp_log_file to #{process_log} which exists? #{File.exist?(process_log)}"
-            @data_point.sdp_log_file = File.read(process_log).lines if File.exist? process_log
+            @data_point.sdp_log_file = inline_log_lines(process_log)
           end
           report_file = "#{simulation_dir}/out.osw"
           @sim_logger.info "Uploading #{report_file} which exists? #{File.exist?(report_file)}"
@@ -271,7 +274,7 @@ module DjJobs
           # Save the /run/run.log to the sdp_log_file. This does not update while running, rather
           # it is saved at the very end of the simulation.
           if File.exist? run_log_file
-            @data_point.sdp_log_file = File.read(run_log_file).lines
+            @data_point.sdp_log_file = inline_log_lines(run_log_file)
           end
 
           # Save the results to the database - I was PUTing these to the server,
@@ -355,7 +358,7 @@ module DjJobs
         log_message = "#{__FILE__} failed with #{e.message}, #{e.backtrace.join("\n")}"
         @sim_logger&.error log_message
         @data_point.set_error_flag
-        @data_point.sdp_log_file = File.read(run_log_file).lines if File.exist? run_log_file
+        @data_point.sdp_log_file = inline_log_lines(run_log_file)
       ensure
         @sim_logger.info "cleaning up /tmp directory"
         #remove xmlvalidation directories left in /tmp from OS
@@ -626,6 +629,32 @@ module DjJobs
         @sim_logger&.error "Could not save report #{display_name} with message: #{e.message} in #{e.backtrace.join("\n")}"
         return false
       end
+    end
+
+    def inline_log_lines(log_path)
+      return [] unless File.exist?(log_path)
+
+      log_size = File.size(log_path)
+      lines = []
+
+      File.open(log_path, 'rb') do |file|
+        if log_size > MAX_INLINE_SDP_LOG_BYTES
+          file.seek(-MAX_INLINE_SDP_LOG_BYTES, IO::SEEK_END)
+          file.gets
+        end
+
+        lines = file.readlines.last(MAX_INLINE_SDP_LOG_LINES)
+      end
+
+      if log_size > MAX_INLINE_SDP_LOG_BYTES
+        omitted_bytes = log_size - MAX_INLINE_SDP_LOG_BYTES
+        lines.unshift("[OpenStudio Server truncated the inline datapoint log by #{omitted_bytes} bytes. Download the Datapoint Simulation Log result file for the full output.]\n")
+      end
+
+      lines
+    rescue StandardError => e
+      @sim_logger&.warn "Could not read inline datapoint log #{log_path}: #{e.message}"
+      []
     end
 
     def run_script_with_args(script_name)

--- a/server/spec/features/dj_run_simulation_data_point_spec.rb
+++ b/server/spec/features/dj_run_simulation_data_point_spec.rb
@@ -4,6 +4,7 @@
 # *******************************************************************************
 
 require 'rails_helper'
+require 'tempfile'
 
 RSpec.describe DjJobs::RunSimulateDataPoint, type: :feature, foreground: true do
   before :all do
@@ -229,6 +230,7 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :feature, depends_resque: tru
     rescue Errno::EACCES => e
       puts 'Cannot unlink files, will try and continue'
     end
+
     FactoryBot.create(:project_with_analyses).analyses
 
     @project = Project.first
@@ -260,5 +262,37 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :feature, depends_resque: tru
     # For some reason the worker_logs aren't working within the testing framework. They work in
     # actual deployment. # TODO: Figure out why worker_logs don't show up for tests
     puts @data_point.worker_logs.inspect
+  end
+end
+
+RSpec.describe DjJobs::RunSimulateDataPoint do
+  subject(:job) { described_class.allocate }
+
+  describe '#inline_log_lines' do
+    it 'adds a truncation note for oversized log files' do
+      Tempfile.create('large-sdp-log') do |file|
+        file.write('x' * (described_class::MAX_INLINE_SDP_LOG_BYTES + 100))
+        file.write("\nretained-line\n")
+        file.flush
+
+        lines = job.send(:inline_log_lines, file.path)
+
+        expect(lines.first).to include('OpenStudio Server truncated the inline datapoint log')
+        expect(lines.first).to include("last #{described_class::MAX_INLINE_SDP_LOG_BYTES} bytes")
+      end
+    end
+
+    it 'adds a truncation note for logs over the line cap' do
+      Tempfile.create('many-lines-sdp-log') do |file|
+        (described_class::MAX_INLINE_SDP_LOG_LINES + 1).times { |i| file.puts("line #{i}") }
+        file.flush
+
+        lines = job.send(:inline_log_lines, file.path)
+
+        expect(lines.length).to eq(described_class::MAX_INLINE_SDP_LOG_LINES + 1)
+        expect(lines.first).to include('OpenStudio Server truncated the inline datapoint log')
+        expect(lines.first).to include("#{described_class::MAX_INLINE_SDP_LOG_LINES} lines")
+      end
+    end
   end
 end


### PR DESCRIPTION
An error shows up with large simulation logs that BSON record is >16MB. This PR will truncate the log and make a note to download the file instead of saving it in the database. The failure was silent and causes the analysis to not finish. This should improve the robustness.