### PR TITLE
Guard nil datapoint in RunSimulateDataPoint rescue logging

### DIFF
--- a/server/app/jobs/resque_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/resque_jobs/run_simulate_data_point.rb
@@ -51,16 +51,20 @@ module ResqueJobs
         puts msg
       end 
     rescue SignalException, Errno::ENOSPC, Resque::DirtyExit, Resque::TermException, Resque::PruneDeadWorkerDirtyExit => e
-      # Log the termination and re-enqueue attempt
-      d.add_to_rails_log("Worker Caught Exception: #{e.inspect}")#: Re-enqueueing DataPoint ID #{data_point_id}")
+      # Log the termination and re-enqueue attempt. d is nil when DataPoint.find above
+      # raised (e.g. the datapoint was deleted), so guard it - otherwise the rescue itself
+      # crashes with NoMethodError and masks the real error, leaving a non-retryable job.
+      msg = "Worker Caught Exception: #{e.inspect}"#: Re-enqueueing DataPoint ID #{data_point_id}")
+      d.nil? ? Rails.logger.warn(msg) : d.add_to_rails_log(msg)
       #Resque.enqueue_to(:requeued, self, data_point_id, options)
       #puts "DataPoint #{data_point_id} re-enqueued."
-      puts "Worker Caught Exception: #{e.inspect}"
+      puts msg
     rescue => e
-      d.add_to_rails_log("Worker Caught Unhandled Exception: #{e.message}")#: Re-enqueueing DataPoint ID #{data_point_id}")
+      msg = "Worker Caught Unhandled Exception: #{e.message}"#: Re-enqueueing DataPoint ID #{data_point_id}")
+      d.nil? ? Rails.logger.warn(msg) : d.add_to_rails_log(msg)
       #Resque.enqueue_to(:requeued, self, data_point_id, options)
       #puts "Unhandled exception, re-enqueued DataPoint."
-      puts "Worker Caught Unhandled Exception: #{e.message}"
+      puts msg
     end
   end
 end

--- a/server/spec/models/resque_run_simulate_data_point_hardening_spec.rb
+++ b/server/spec/models/resque_run_simulate_data_point_hardening_spec.rb
@@ -112,5 +112,15 @@ RSpec.describe ResqueJobs::RunSimulateDataPoint, type: :model do
         described_class.perform(data_point.id)
       end
     end
+
+    context 'when the datapoint lookup itself fails (d is nil in the rescue path)' do
+      it 'logs the original error instead of raising NoMethodError on nil ' \
+         '(so the job fails cleanly and can be retried, not crash the rescue)' do
+        missing_id = data_point.id
+        data_point.destroy!
+
+        expect { described_class.perform(missing_id) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

`ResqueJobs::RunSimulateDataPoint.perform` binds `d = DataPoint.find(data_point_id)` on its first line. When that lookup raises (the datapoint was deleted, DB blip, etc.), `d` is still nil when either `rescue` block runs, and both call `d.add_to_rails_log(...)`. That raises `NoMethodError: undefined method 'add_to_rails_log' for nil`, which masks the original error and turns a would-be retryable failure into a permanent failed job. Same nil hazard in the `SignalException`/`DirtyExit` rescue.

Fixes #848.

## Change

Guard `d` in both rescue paths: log through `add_to_rails_log` when the datapoint is present, otherwise fall back to `Rails.logger.warn` so the root cause is still recorded. This mirrors the nil-safe rescue logging already added to the sibling `InitializeAnalysis` job (#841). No behavior change on the happy path.

## Test

Added a regression case to `resque_run_simulate_data_point_hardening_spec.rb`: destroying the datapoint before `perform` runs and asserting it no longer raises. The full spec needs the docker Rails/Postgres/Redis stack, so I could not run the suite locally; the change is `ruby -c` clean and confined to the two rescue branches.