### PR TITLE
Keep DataPoint under BSON cap; terminal state on worker failure (fixes #851)

### DIFF
--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -13,6 +13,8 @@ module DjJobs
 
     MAX_INLINE_SDP_LOG_BYTES = 5_000_000
     MAX_INLINE_SDP_LOG_LINES = 5_000
+    MAX_INLINE_RESULTS_BYTES = 5_000_000
+    MAX_INLINE_RESULTS_MEASURE_BYTES = 1_000_000
 
     # Raised (instead of a bare String) when the downloaded analysis.zip cannot be
     # extracted, so initialize_worker's cleanup can distinguish this deterministic
@@ -293,6 +295,7 @@ module DjJobs
           results_file = "#{run_dir}/measure_attributes.json"
           if File.exist? results_file
             results = JSON.parse(File.read(results_file), symbolize_names: true)
+            results = prune_oversized_results(results, File.size(results_file))
             @data_point.update(results: results)
           else
             #run_result = :errored  #This should not be an error for workflows with no measures
@@ -367,6 +370,15 @@ module DjJobs
       rescue ScriptError, NoMemoryError, StandardError => e
         log_message = "#{__FILE__} failed with #{e.message}, #{e.backtrace.join("\n")}"
         @sim_logger&.error log_message
+        # Drop any unsaved (possibly oversized) attributes first, otherwise the
+        # terminal-state saves below re-raise the same persistence error (e.g.
+        # a results document over the BSON size limit) and the DataPoint is
+        # left as 'started' forever.
+        begin
+          @data_point.reload
+        rescue StandardError
+          nil
+        end
         @data_point.set_error_flag
         @data_point.sdp_log_file = inline_log_lines(run_log_file)
       ensure
@@ -736,6 +748,24 @@ module DjJobs
         @sim_logger&.error "Could not save report #{display_name} with message: #{e.message} in #{e.backtrace.join("\n")}"
         return false
       end
+    end
+
+    # Keep the DataPoint document under mongo's BSON document cap: when
+    # measure_attributes.json is oversized, replace any per-measure result
+    # whose serialized size exceeds MAX_INLINE_RESULTS_MEASURE_BYTES with a
+    # stub instead of failing the save after a successful simulation. Small
+    # results (objective values etc.) are preserved so algorithms still work.
+    def prune_oversized_results(results, file_size)
+      return results unless file_size > MAX_INLINE_RESULTS_BYTES && results.is_a?(Hash)
+
+      results.each do |measure, values|
+        size = values.to_json.bytesize
+        next unless size > MAX_INLINE_RESULTS_MEASURE_BYTES
+
+        @sim_logger&.warn "Result for '#{measure}' is #{size} bytes; storing a stub instead to keep the DataPoint under the BSON document limit."
+        results[measure] = { openstudio_server_truncated: "result of #{size} bytes exceeded #{MAX_INLINE_RESULTS_MEASURE_BYTES} bytes and was not stored inline" }
+      end
+      results
     end
 
     def inline_log_lines(log_path)

--- a/server/app/jobs/resque_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/resque_jobs/run_simulate_data_point.rb
@@ -84,6 +84,19 @@ module ResqueJobs
       d.add_to_rails_log(msg)
       #Resque.enqueue_to(:requeued, self, data_point_id, options)
       #puts "Unhandled exception, re-enqueued DataPoint."
+      # Leave the DataPoint in a terminal state instead of 'started' forever.
+      # R-driven algorithms (morris/sobol/nsga2) poll the dp and otherwise spin
+      # until their own timeout, then fail the whole analysis on all-penalty
+      # results. reload first: a dirty in-memory document (e.g. results over
+      # the BSON size limit) would make these saves re-raise the same error.
+      # d is non-nil here: the nil case re-raised above.
+      begin
+        d.reload
+        d.set_error_flag
+        d.set_complete_state
+      rescue StandardError => e2
+        puts "Could not set terminal state on DataPoint #{data_point_id}: #{e2.message}"
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #851.

## Problem

A datapoint whose simulation SUCCEEDS can still be lost: an oversized artifact (observed: generic_qaqc summary_report, ~19MB inlined via `results`) pushes the DataPoint document over mongo's 16MB BSON cap. The save raises, every later save of the now-dirty document re-raises, the Resque wrapper's catch-all rescue only logs, and the dp is left `status: started` forever. R-driven algorithms (morris/sobol/nsga2) then poll to timeout, fill the design with 1e+18 penalties, and crash in result assembly — one oversized measure report kills the whole analysis with no failure recorded.

Full forensics in #851 (docker 3.11.0 images, 27-zone model, morris r=6).

## Changes

- **`prune_oversized_results`** (dj job): when `measure_attributes.json` exceeds `MAX_INLINE_RESULTS_BYTES` (5MB), per-measure results larger than `MAX_INLINE_RESULTS_MEASURE_BYTES` (1MB) are replaced with a stub. Small results — objective values the algorithms need — are preserved. Complements the existing `MAX_INLINE_SDP_LOG_*` truncation.
- **dj rescue path**: `reload` the DataPoint before terminal-state saves so a dirty oversized document can't re-raise the same persistence error out of the rescue.
- **Resque wrapper**: on unhandled exception, set `error flag` + `complete state` (after reload) so the dp reaches a terminal state (`completed` / `datapoint failure`) instead of zombie-ing as `started`.

## Testing

- `ruby -c` on both files.
- Failure mode reproduced end-to-end on the 3.11.0 docker stack before the fix (see #851); with oversized results stubbed the same workflow completes (verified by disabling generic_qaqc checks client-side — equivalent payload reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
