### PR TITLE
Fix nil-DataPoint crash masking real errors in ResqueJobs::RunSimulateDataPoint

### DIFF
--- a/server/app/jobs/resque_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/resque_jobs/run_simulate_data_point.rb
@@ -16,6 +16,15 @@ module ResqueJobs
 
     def self.perform(data_point_id, options = {})
       d = DataPoint.find(data_point_id)
+      # raise_not_found_error is false in every env (mongoid.yml), so find returns nil
+      # for a datapoint deleted between enqueue and perform - there is nothing to run
+      # or log to, so skip instead of crashing on the nil below (#846).
+      if d.nil?
+        msg = "SKIPPING #{data_point_id}: DataPoint no longer exists"
+        Rails.logger.error msg
+        puts msg
+        return
+      end
       statuses = d.get_statuses
       # A DP can be requeued when a worker is getting shutdown as a spot instance.
       # When that happens the status gets changed from ':started' to ':queued' but the resque job is still processing on the worker until it is killed.
@@ -51,16 +60,30 @@ module ResqueJobs
         puts msg
       end 
     rescue SignalException, Errno::ENOSPC, Resque::DirtyExit, Resque::TermException, Resque::PruneDeadWorkerDirtyExit => e
-      # Log the termination and re-enqueue attempt
-      d.add_to_rails_log("Worker Caught Exception: #{e.inspect}")#: Re-enqueueing DataPoint ID #{data_point_id}")
+      # Log the termination and re-enqueue attempt.
+      # d is nil when DataPoint.find itself raised (e.g. transient Mongo failure under
+      # load - #846): there is no datapoint to log to, and calling add_to_rails_log on
+      # nil masked the root cause with a NoMethodError, leaving a non-retryable failed
+      # job. Log with the id and re-raise so Resque records the original error instead.
+      msg = "Worker Caught Exception: #{e.inspect}"#: Re-enqueueing DataPoint ID #{data_point_id}")
+      puts msg
+      if d.nil?
+        Rails.logger.error "#{msg} (data_point_id=#{data_point_id}, DataPoint.find failed)"
+        raise
+      end
+      d.add_to_rails_log(msg)
       #Resque.enqueue_to(:requeued, self, data_point_id, options)
       #puts "DataPoint #{data_point_id} re-enqueued."
-      puts "Worker Caught Exception: #{e.inspect}"
     rescue => e
-      d.add_to_rails_log("Worker Caught Unhandled Exception: #{e.message}")#: Re-enqueueing DataPoint ID #{data_point_id}")
+      msg = "Worker Caught Unhandled Exception: #{e.message}"#: Re-enqueueing DataPoint ID #{data_point_id}")
+      puts msg
+      if d.nil?
+        Rails.logger.error "#{msg} (data_point_id=#{data_point_id}, DataPoint.find failed)"
+        raise
+      end
+      d.add_to_rails_log(msg)
       #Resque.enqueue_to(:requeued, self, data_point_id, options)
       #puts "Unhandled exception, re-enqueued DataPoint."
-      puts "Worker Caught Unhandled Exception: #{e.message}"
     end
   end
 end

--- a/server/spec/models/resque_run_simulate_data_point_hardening_spec.rb
+++ b/server/spec/models/resque_run_simulate_data_point_hardening_spec.rb
@@ -112,5 +112,53 @@ RSpec.describe ResqueJobs::RunSimulateDataPoint, type: :model do
         described_class.perform(data_point.id)
       end
     end
+
+    context 'when the datapoint cannot be loaded, so d is nil or never bound (regression for #846/#848)' do
+      # Incident (k8s/KEDA, ~1,500+ concurrent workers): a datapoint deleted between
+      # enqueue and perform makes DataPoint.find return nil (raise_not_found_error is
+      # false in every env in mongoid.yml), so d.get_statuses raises; a transient Mongo
+      # failure under load makes find itself raise. Either way both rescue clauses then
+      # called d.add_to_rails_log on a nil d, so the Resque failed queue filled with
+      # masking "NoMethodError ... for nil" entries while the real root cause was
+      # swallowed and the datapoint sat permanently stuck in its prior status.
+      before do
+        # The rescue clause names Resque::* error classes, which Ruby only evaluates
+        # when an exception actually propagates. The resque gem is not bundled on
+        # Windows (server/Gemfile gates it), so define stand-ins when absent to keep
+        # this spec runnable outside the docker stack.
+        unless defined?(Resque::DirtyExit)
+          stub_const('Resque::DirtyExit', Class.new(StandardError))
+          stub_const('Resque::TermException', Class.new(StandardError))
+          stub_const('Resque::PruneDeadWorkerDirtyExit', Class.new(StandardError))
+        end
+      end
+
+      it 'skips cleanly (no dispatch, no NoMethodError) when the datapoint was deleted between enqueue and perform' do
+        gone_id = data_point.id.to_s
+        data_point.destroy!
+
+        expect(DjJobs::RunSimulateDataPoint).not_to receive(:new)
+
+        expect { described_class.perform(gone_id) }.not_to raise_error
+      end
+
+      it 'surfaces a transient find failure (e.g. Mongo timeout under load) as itself, not a masking NoMethodError' do
+        transient_error = Class.new(StandardError)
+        allow(DataPoint).to receive(:find).and_raise(transient_error, 'socket timeout')
+
+        expect { described_class.perform(data_point.id) }.to raise_error(transient_error, 'socket timeout')
+      end
+
+      it 'still logs to the datapoint and swallows when d IS bound (pre-existing rescue behavior preserved)' do
+        set_data_point_status(status: 'na')
+        analysis.update!(run_flag: true)
+        allow(DataPoint).to receive(:find).and_return(data_point)
+        allow(data_point).to receive(:add_to_rails_log).and_call_original
+        allow(DjJobs::RunSimulateDataPoint).to receive(:new).and_raise(StandardError, 'boom')
+
+        expect { described_class.perform(data_point.id) }.not_to raise_error
+        expect(data_point).to have_received(:add_to_rails_log).with('Worker Caught Unhandled Exception: boom')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

Both rescue clauses in `ResqueJobs::RunSimulateDataPoint.perform` call `d.add_to_rails_log` on a nil `d`, raising `NoMethodError: undefined method 'add_to_rails_log' for nil` — masking the root cause in the Resque failed queue and leaving the datapoint permanently stuck in its prior status (#846, observed at k8s/KEDA scale with ~1,500+ workers).

Two distinct paths get there (`raise_not_found_error: false` in every env in `mongoid.yml`):
1. Datapoint deleted between enqueue and perform → `find` returns **nil** (no DocumentNotFound) → `d.get_statuses` raises the first NoMethodError → rescue raises the second (the one Resque records)
2. Transient Mongo failure under load → `find` itself raises → `d` never bound → same rescue crash

## Change

- Explicit nil check after `find`: log `SKIPPING <id>: DataPoint no longer exists` and return
- Both rescues: when `d` is nil, log via `Rails.logger.error` with the datapoint id and **re-raise the original error** so the failed queue records the root cause; when `d` is bound, behavior unchanged (log to datapoint, swallow)

## Test

Regression specs added to `resque_run_simulate_data_point_hardening_spec.rb` — written first and verified red on develop (both reproduce the masking NoMethodError), green after the fix (11 examples, 0 failures, run locally against mongod). `Resque::*` error consts are stubbed when the gem is absent so the spec runs outside the docker stack (resque is not bundled on Windows).

Fixes #846. Supersedes #850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)