### PR TITLE
Fix CI failures on mvp-external-batch-fixes (all 3 jobs)

### DIFF
--- a/docker/R/install_packages.R
+++ b/docker/R/install_packages.R
@@ -7,8 +7,24 @@
 # OpenStudio-R image here:
 # https://raw.githubusercontent.com/NREL/docker-openstudio-r/master/base_packages.R
 
+# Install from a date-frozen CRAN snapshot (Posit Package Manager) so the UNPINNED
+# dependencies of the pinned packages below also resolve deterministically. On
+# 2026-07-16 a mid-day CRAN publish (ggrepel requiring ggplot2 >= 3.5.2/gtable >=
+# 0.3.6) broke image rebuilds that had passed hours earlier. The __linux__/jammy
+# path serves prebuilt binaries for the base image's Ubuntu 22.04 + R 4.4 (much
+# faster than source compiles); the plain snapshot path is the source fallback.
+# To take newer packages, bump the snapshot date deliberately.
+snapshot_repos = c(
+    'https://packagemanager.posit.co/cran/__linux__/jammy/2026-07-15',
+    'https://packagemanager.posit.co/cran/2026-07-15'
+)
+# Posit Package Manager only serves Linux binaries to clients whose User-Agent
+# announces the R version; set it explicitly so install.packages gets binaries.
+options(HTTPUserAgent = sprintf('R/%s R (%s)', getRversion(),
+    paste(getRversion(), R.version$platform, R.version$arch, R.version$os)))
+
 # Function for installing and verifying that the package was installed correctly (i.e. can be loaded)
-install_and_verify = function(package_name, version=NULL, configure.args=c(), repos=c('http://cloud.r-project.org', 'http://cran.r-project.org')){
+install_and_verify = function(package_name, version=NULL, configure.args=c(), repos=snapshot_repos){
     if (!is.null(version)) {
         print(paste("Installing package", package_name, "version", version))
         remotes::install_version(package_name, version=version, repos=repos)

--- a/external_batch/nomad/sync_results.rb
+++ b/external_batch/nomad/sync_results.rb
@@ -67,9 +67,16 @@ sync_cmd = if is_s3
 elsif options[:ssh_host]
   ssh_key_arg = options[:ssh_key] ? "-i #{options[:ssh_key]}" : ''
   "rsync -avz -e \"ssh #{ssh_key_arg} -o StrictHostKeyChecking=no\" \"#{options[:ssh_host]}:#{options[:results_uri]}/\" \"#{results_dir}/\""
-else
-  # For NFS/local filesystem, use rsync
-  "rsync -a --quiet \"#{options[:results_uri]}/\" \"#{results_dir}/\""
+end
+
+# NFS/local mount needs no external tool: mirror in-process so the sync loop
+# also works on hosts without rsync (Windows dev boxes, slim containers).
+def sync_local(results_uri, results_dir)
+  unless Dir.exist?(results_uri)
+    warn "results dir not yet present (will retry): #{results_uri}"
+    return
+  end
+  FileUtils.cp_r(File.join(results_uri, '.'), results_dir)
 end
 
 def all_chunks_done?(results_dir, num_chunks)
@@ -77,7 +84,11 @@ def all_chunks_done?(results_dir, num_chunks)
 end
 
 loop do
-  system(sync_cmd) || warn("sync failed (will retry): #{sync_cmd}")
+  if sync_cmd
+    system(sync_cmd) || warn("sync failed (will retry): #{sync_cmd}")
+  else
+    sync_local(options[:results_uri], results_dir)
+  end
   done = all_chunks_done?(results_dir, num_chunks)
   markers = (0...num_chunks).count { |i| File.exist?(File.join(results_dir, "chunk_#{i}.done")) }
   puts "[sync_results #{Time.now}] #{markers}/#{num_chunks} chunks done"

--- a/server/app/lib/analysis_library/sampling/lhs.rb
+++ b/server/app/lib/analysis_library/sampling/lhs.rb
@@ -128,18 +128,24 @@ module AnalysisLibrary::Sampling
 
         samples[var.id.to_s] = variable_samples
 
-      # NOTE: the R backend renders a histogram PreflightImage per variable here.
-      # The Ruby backend now also generates histogram images (pure Ruby implementation).
-      logger.info "Generating preflight histogram for #{var.name} (Ruby sampling backend)"
-      histogram_file = generate_ruby_histogram(var.name, variable_samples)
-      if histogram_file && File.exist?(histogram_file)
-        pfi = PreflightImage.add_from_disk(var.id, 'histogram', histogram_file)
-        var.preflight_images << pfi unless var.preflight_images.include?(pfi)
-        # Clean up the temporary file
-        FileUtils.rm_f(histogram_file)
-      else
-        logger.info "No histogram file generated for #{var.name}"
-      end
+        # NOTE: the R backend renders a histogram PreflightImage per variable here.
+        # The Ruby backend now also generates histogram images (pure Ruby implementation).
+        logger.info "Generating preflight histogram for #{var.name} (Ruby sampling backend)"
+        histogram_file = generate_ruby_histogram(var.name, variable_samples)
+        if histogram_file && File.exist?(histogram_file)
+          begin
+            pfi = PreflightImage.add_from_disk(var.id, 'histogram', histogram_file)
+            var.preflight_images << pfi unless var.preflight_images.include?(pfi)
+          rescue StandardError => e
+            # Attaching runs paperclip styles through ImageMagick; hosts without it
+            # (PAT-local installs, bare CI runners) must still be able to sample.
+            logger.warn "Skipping preflight histogram for #{var.name}: #{e.message}"
+          ensure
+            FileUtils.rm_f(histogram_file)
+          end
+        else
+          logger.info "No histogram file generated for #{var.name}"
+        end
 
         var.r_index = i_var + 1 # r_index is 1-based
         var.save!

--- a/server/spec/models/external_batch_nomad_spec.rb
+++ b/server/spec/models/external_batch_nomad_spec.rb
@@ -6,11 +6,13 @@
 require 'rails_helper'
 require 'tmpdir'
 require 'rbconfig'
+require 'socket'
 
 # Nomad control-plane helpers (submit_nomad.rb, sync_results.rb) exercised
-# against a stub `nomad` CLI that emulates the Nomad API. The full-pipeline
-# spec walks the exact Nomad shape: package -> submit (push to NFS/S3) -> array
-# tasks run against the NFS/S3 copy -> sync results down -> ingest.
+# against a stub of the Nomad HTTP API — submit_nomad.rb drives
+# POST /v1/jobs/parse and POST /v1/jobs, it never shells out to a `nomad` CLI.
+# The full-pipeline spec walks the exact Nomad shape: package -> submit (push
+# to NFS) -> array tasks run against the NFS copy -> sync results down -> ingest.
 RSpec.describe 'ExternalBatch Nomad helpers', type: :model do
   include ExternalBatchHelpers
 
@@ -19,18 +21,13 @@ RSpec.describe 'ExternalBatch Nomad helpers', type: :model do
   around do |example|
     Dir.mktmpdir do |tmp|
       @batch_root = File.join(tmp, 'batch')
-      @fake_nomad_root = File.join(tmp, 'fake_nomad')  # Simulates the shared storage (NFS or S3 root)
-      @stub_log = File.join(tmp, 'nomad_calls.log')
-      FileUtils.mkdir_p [@batch_root, @fake_nomad_root]
+      @nfs_root = File.join(tmp, 'fake_nfs') # simulates the shared NFS mount
+      FileUtils.mkdir_p [@batch_root, @nfs_root]
       ENV['OS_SERVER_EXTERNAL_BATCH_ROOT'] = @batch_root
-      ENV['FAKE_NOMAD_ROOT'] = @fake_nomad_root
-      ENV['NOMAD_STUB_LOG'] = @stub_log
       begin
         example.run
       ensure
         ENV.delete('OS_SERVER_EXTERNAL_BATCH_ROOT')
-        ENV.delete('FAKE_NOMAD_ROOT')
-        ENV.delete('NOMAD_STUB_LOG')
       end
     end
   end
@@ -42,60 +39,58 @@ RSpec.describe 'ExternalBatch Nomad helpers', type: :model do
     rescue Errno::EACCES
       puts 'Cannot unlink files, will try and continue'
     end
-    @nomad_cmd = "\"#{RbConfig.ruby}\" \"#{write_stub_nomad(@fake_nomad_root)}\""
+    @nomad_requests = []
+    @nomad_api = TCPServer.new('127.0.0.1', 0)
+    @nomad_addr = "http://127.0.0.1:#{@nomad_api.addr[1]}"
+    @nomad_api_thread = Thread.new { serve_stub_nomad_api(@nomad_api, @nomad_requests) }
   end
 
-  def fake_nomad_batch_dir(bucket, analysis)
-    # For our stub, we treat the fake_nomad_root as the base for NFS/S3-like paths
-    File.join(@fake_nomad_root, bucket, 'runs', "analysis_#{analysis.id}")
+  after do
+    @nomad_api&.close
+    @nomad_api_thread&.kill
   end
 
-  # Stub of the Nomad CLI: 
-  #   `nomad job run -output=json <job_file>` prints a fake job ID and logs the invocation.
-  #   Every invocation is appended to NOMAD_STUB_LOG as a JSON argv line.
-  def write_stub_nomad(dir)
-    stub_path = File.join(dir, 'fake_nomad.rb')
-    File.write(stub_path, <<~RUBY)
-      require 'json'
-      require 'fileutils'
-
-      fake_root = ENV['FAKE_NOMAD_ROOT'] || abort('FAKE_NOMAD_ROOT not set')
-      log_path = ENV['NOMAD_STUB_LOG']
-      File.open(log_path, 'a') { |f| f.puts JSON.generate(ARGV) } if log_path
-
-      argv = ARGV.dup
-      # Remove the -address argument if present (we don't use it in the stub)
-      if (i = argv.index('-address'))
-        argv.slice!(i, 2)
+  # Minimal stub of the two Nomad API calls submit_nomad.rb makes:
+  # POST /v1/jobs/parse (HCL -> job JSON) and POST /v1/jobs (submit).
+  # Records each request so examples can assert on the rendered job.
+  def serve_stub_nomad_api(server, requests)
+    loop do
+      client = begin
+        server.accept
+      rescue IOError, Errno::EBADF, Errno::EINVAL
+        break
       end
-      # Also handle --address=...
-      if (i = argv.index { |arg| arg.start_with?('--address=') })
-        argv.slice!(i, 1)
-      end
+      begin
+        request_line = client.gets
+        next unless request_line
 
-      service = argv.shift
-      case service
-      when 'job'
-        subcommand = argv.shift
-        case subcommand
-        when 'run'
-          # Expect: -output=json <job_file>
-          output_flag = argv.shift
-          output_value = argv.shift
-          job_file = argv.shift
-          abort "Expected -output=json, got #{output_flag} #{output_value}" unless output_flag == '-output' && output_value == 'json'
-          # Check that the job file exists (we don't need to read it)
-          abort "Job file not found: #{job_file}" unless File.exist?(job_file)
-          # Output a fake job ID JSON
-          puts JSON.generate({ 'job' => { 'ID' => 'fake-job-id-123' } })
-        else
-          abort "unsupported nomad job subcommand \#{subcommand}"
+        path = request_line.split(' ')[1]
+        content_length = 0
+        while (line = client.gets) && line != "\r\n"
+          content_length = line.split(':', 2)[1].to_i if line.downcase.start_with?('content-length')
         end
-      else
-        abort "unsupported nomad service \#{service}"
+        body = content_length.positive? ? client.read(content_length) : ''
+        requests << { path: path, body: JSON.parse(body) }
+        response = path == '/v1/jobs/parse' ? { 'ID' => 'stub-parsed-job' } : { 'EvalID' => 'stub-eval-123' }
+        payload = JSON.generate(response)
+        client.write "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: #{payload.bytesize}\r\nConnection: close\r\n\r\n#{payload}"
+      ensure
+        client.close
       end
-    RUBY
-    stub_path
+    end
+  end
+
+  # submit_nomad.rb lays the shared location out as <package-location>/analysis_<id>/{package,results}
+  def nfs_batch_dir(analysis)
+    File.join(@nfs_root, "analysis_#{analysis.id}")
+  end
+
+  def submit!(analysis)
+    system(RbConfig.ruby, File.join(NOMAD_DIR, 'submit_nomad.rb'),
+           ExternalBatch.batch_dir(analysis.id),
+           '--nomad-addr', @nomad_addr,
+           '--job-template', File.join(NOMAD_DIR, 'templates', 'job_array.hcl'),
+           '--package-location', @nfs_root)
   end
 
   describe 'submit_nomad.rb' do
@@ -103,48 +98,30 @@ RSpec.describe 'ExternalBatch Nomad helpers', type: :model do
       analysis, dps = create_fixture_analysis(num_dps: 3)
       ExternalBatch::Packager.new(analysis, dps, dps_per_chunk: 2).package!
 
-      ok = system(RbConfig.ruby, File.join(NOMAD_DIR, 'submit_nomad.rb'),
-                  ExternalBatch.batch_dir(analysis.id),
-                  '--nomad-addr', 'http://nomad:4646',
-                  '--job-template', File.join(NOMAD_DIR, 'templates', 'job_array.hcl'),
-                  '--package-location', 'file://' + @fake_nomad_root,  # Using file:// to simulate NFS? Actually, the script expects either S3 or a local path. We'll use a local path.
-                  '--nomad-cmd', @nomad_cmd)
-      expect(ok).to be(true), 'submit_nomad.rb exited non-zero'
+      expect(submit!(analysis)).to be(true), 'submit_nomad.rb exited non-zero'
 
-      # package mirrored into the fake nomad root (simulating NFS)
-      expect(File).to exist(File.join(fake_nomad_batch_dir('analysis_runs', analysis), 'package', 'manifest.json'))
-      expect(Dir).to exist(File.join(fake_nomad_batch_dir('analysis_runs', analysis), 'package', "analysis_#{analysis.id}"))
+      # package mirrored into the fake NFS root
+      expect(File).to exist(File.join(nfs_batch_dir(analysis), 'package', 'manifest.json'))
+      expect(Dir).to exist(File.join(nfs_batch_dir(analysis), 'package', "analysis_#{analysis.id}"))
 
-      # nomad job run called with the right shape
-      calls = File.readlines(@stub_log).map { |l| JSON.parse(l) }
-      run_call = calls.detect { |c| c[0] == 'job' && c[1] == 'run' }
-      expect(run_call).not_to be_nil
-      expect(run_call).to include('-output', 'json')
-      # The job file is a temporary file, so we can't check its content easily, but we can check that the command was called.
-      # We can also check the environment by looking at the rendered job? Not in the stub.
-      # Instead, we can check that the package and results URIs were set correctly by examining the job file? 
-      # But we stubbed Nomad, so we don't have the rendered job. We'll trust that the submit_nomad.rb script does the replacement.
-      # Alternatively, we can check the logs for the put command? Not logged.
-      # We'll at least verify that the script ran and produced a job ID.
+      # HCL parsed then submitted, with the template rendered for 2 chunks
+      expect(@nomad_requests.map { |r| r[:path] }).to eq ['/v1/jobs/parse', '/v1/jobs']
+      hcl = @nomad_requests[0][:body]['JobHCL']
+      expect(hcl).to include('count = 2') # 3 dps at 2/chunk = 2 array tasks
+      expect(hcl).to include("osaf-nomad-analysis-#{analysis.id}")
+      expect(hcl).to include(File.join(@nfs_root, "analysis_#{analysis.id}", 'package'))
+      expect(hcl).to include(File.join(@nfs_root, "analysis_#{analysis.id}", 'results'))
+      expect(@nomad_requests[1][:body]['Job']).to eq('ID' => 'stub-parsed-job')
     end
 
-    it 'submits a plain job with CHUNK_INDEX for a single chunk (Nomad arrays need count >= 2)' do
+    it 'renders a single-task group for a single chunk' do
       analysis, dps = create_fixture_analysis(num_dps: 2)
       ExternalBatch::Packager.new(analysis, dps, dps_per_chunk: 50).package! # 1 chunk
 
-      ok = system(RbConfig.ruby, File.join(NOMAD_DIR, 'submit_nomad.rb'),
-                  ExternalBatch.batch_dir(analysis.id),
-                  '--nomad-addr', 'http://nomad:4646',
-                  '--job-template', File.join(NOMAD_DIR, 'templates', 'job_array.hcl'),
-                  '--package-location', @fake_nomad_root,
-                  '--nomad-cmd', @nomad_cmd)
-      expect(ok).to be true
+      expect(submit!(analysis)).to be true
 
-      run_call = File.readlines(@stub_log).map { |l| JSON.parse(l) }.detect { |c| c[0] == 'job' && c[1] == 'run' }
-      expect(run_call).not_to be_nil
-      # We cannot easily check the job file content, but we know that for 1 chunk, the script should set count=1.
-      # The Nomad job template uses count = {{NUM_CHUNKS}}. So if NUM_CHUNKS is 1, then count=1.
-      # We'll rely on the fact that the script works and the job is submitted.
+      hcl = @nomad_requests[0][:body]['JobHCL']
+      expect(hcl).to include('count = 1')
     end
   end
 
@@ -154,31 +131,23 @@ RSpec.describe 'ExternalBatch Nomad helpers', type: :model do
       ExternalBatch::Packager.new(analysis, dps, dps_per_chunk: 1).package!
       dps.each(&:set_queued_state)
       batch_dir = ExternalBatch.batch_dir(analysis.id)
-      # We'll use the fake_nomad_root as the shared storage (NFS mount)
-      package_location = @fake_nomad_root
 
-      # 1. control plane: push package + "submit" the array job
-      ok = system(RbConfig.ruby, File.join(NOMAD_DIR, 'submit_nomad.rb'), batch_dir,
-                  '--nomad-addr', 'http://nomad:4646',
-                  '--job-template', File.join(NOMAD_DIR, 'templates', 'job_array.hcl'),
-                  '--package-location', package_location,
-                  '--nomad-cmd', @nomad_cmd)
-      expect(ok).to be true
+      # 1. control plane: push package + submit the array job
+      expect(submit!(analysis)).to be true
 
-      # 2. the "array tasks": the fake-nomad batch dir has the same shape as a local
-      #    batch dir, so drive it with the local executor + stub OpenStudio CLI
+      # 2. the "array tasks": the NFS copy has the same shape as a local batch
+      #    dir, so drive it with the local executor + stub OpenStudio CLI
       #    (this is what task_wrapper.sh does inside each Nomad task)
-      stub_cli = write_stub_openstudio(@fake_nomad_root)
+      stub_cli = write_stub_openstudio(@nfs_root)
       ok = system(RbConfig.ruby, File.expand_path('../external_batch/local_executor.rb', Rails.root),
-                  fake_nomad_batch_dir('analysis_runs', analysis),
+                  nfs_batch_dir(analysis),
                   '--openstudio', "\"#{RbConfig.ruby}\" \"#{stub_cli}\"",
                   '--parallel', '2')
       expect(ok).to be(true), 'array-task simulation failed'
 
       # 3. transport: mirror the results down to the server's batch dir
-      results_uri = File.join(package_location, "analysis_runs", "analysis_#{analysis.id}", "results")
       ok = system(RbConfig.ruby, File.join(NOMAD_DIR, 'sync_results.rb'), batch_dir,
-                  '--results-uri', results_uri,
+                  '--results-uri', File.join(nfs_batch_dir(analysis), 'results'),
                   '--interval', '0')
       expect(ok).to be(true), 'sync_results.rb exited non-zero'
 


### PR DESCRIPTION
Fixes the three failing jobs in [run 30320382392](https://github.com/NatLabRockies/OpenStudio-server/actions/runs/30320382392). All failures were introduced on this branch; `develop` is green.

## linux-test / macos-test

**1. Nomad spec rewritten to match `submit_nomad.rb`'s real contract**
The spec stubbed a `nomad` CLI and passed `--nomad-cmd`, but `submit_nomad.rb` has no such option — it drives the Nomad HTTP API (`POST /v1/jobs/parse` → `POST /v1/jobs`) and lays out the shared location as `<loc>/analysis_<id>/{package,results}` (the spec expected `analysis_runs/runs/...`). This was masked by a second bug: the stub was written with an interpolating heredoc, so unescaped `#{output_flag}` raised `NameError` in the `before` hook and killed all 3 examples before the mismatch could surface. The spec now stubs the HTTP API with a minimal in-spec `TCPServer`, asserts on the rendered HCL (`count`, job name, package/results URIs), and runs the full package → submit → array-tasks → sync → ingest pipeline.

**2. `sync_results.rb`: NFS branch no longer requires rsync**
The local/NFS path shelled out to `rsync`; on hosts without it the sync loop spun forever (`--interval 0`). Local mirroring is now in-process `FileUtils.cp_r`; S3 and SSH branches are unchanged.

**3. Ruby LHS backend: preflight histogram attach is non-fatal**
`sample_all_variables` attaches the generated histogram via `PreflightImage.add_from_disk`, which runs paperclip styles through ImageMagick `identify` — not installed on ubuntu-24.04/macos-15 runner images or PAT-local hosts. The attach is now wrapped in a rescue (warn + continue), so sampling degrades gracefully instead of failing the analysis. This is what broke all 5 `sampling_lhs_spec` examples.

## docker

**4. Restore the CRAN snapshot pin in `docker/R/install_packages.R`**
This branch reverted the date-frozen Posit snapshot (ba21522e) back to `cloud.r-project.org`, which picked up RcppParallel 6.1.1 — its configure needs cmake, so `RcppParallel` → `dtwclust` → `sensitivity` cascaded and the rserve image build died. Restored `develop`'s pinned version; the snapshot serves prebuilt jammy binaries, no cmake needed.

## Verification

- `sampling_lhs_spec` + `external_batch_nomad_spec` + `external_batch_aws_spec` + `external_batch_spec`: **30 examples, 0 failures** (local-test env, on a host *without* ImageMagick, so the rescue path in fix 3 is genuinely exercised)
- Fresh `Rscript install_packages.R` inside `nrel/openstudio-r:4.4.0`: exit 0; RcppParallel/dtwclust/sensitivity install as snapshot binaries

Note: this branch forked from 5554f4a9 and is 7 commits behind `develop`; a rebase is worth doing regardless (it also dropped the rserve CI caching from ba21522e's workflow changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)