### PR TITLE
Keep the OpenStudio 3.10.0 downgrade version-only (restore ubuntu-24.04, macos-15, MongoDB 8)

### DIFF
--- a/.github/workflows/openstudio-server-tests.yml
+++ b/.github/workflows/openstudio-server-tests.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   linux-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Delete huge unnecessary tools folder
       run: rm -rf /opt/hostedtoolcache 
@@ -65,7 +65,7 @@ jobs:
         name: openstudio-server-gems-linux
         path: build/NREL/export/*.tar.gz
   macos-test:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps: 
     - name: Check out repository
       uses: actions/checkout@v4
@@ -100,7 +100,7 @@ jobs:
         name: openstudio-server-gems-darwin
         path: build/NREL/export/*.tar.gz
   docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Delete huge unnecessary tools folder
       run: rm -rf /opt/hostedtoolcache 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   docker-scan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps: 
     - name: Check out repository
       uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@ OpenStudio Server
 
 Version 3.10.0
 -------------
-* Bumped OpenStudio Server version to 3.10.0.
-* Reverted CI and build infrastructure to 3.10.0 baseline:
-* Migrated Ubuntu CI from 24.04 back to 22.04.
-* Updated macOS runner back to macOS 13.
-* Updated MongoDB version used in CI to 6.x.
-* Updated container tags and packaging logic for 3.10.0 targets.
-* Updated packaged Ruby and dependency handling for Ubuntu 22.04.
+* Pinned OpenStudio at 3.10.0 (86d7e215a1); server version set to 3.10.0.
+* Updated CI and build infrastructure to support newer platforms:
+* Migrated Ubuntu CI from 22.04 to 24.04.
+* Updated macOS runner and version checks to support macOS 15.
+* Updated MongoDB version used in CI to 8.x.
+* Updated container tags and packaging logic for modern OS targets.
+* Updated packaged Ruby and dependency handling for Ubuntu 24.04.
+* Adjusted test expectations in docker_stack_requeue_spec.rb to reflect updated behavior.
+* Cleaned up legacy Windows install and packaging logic.
 * Custom Gems working again https://github.com/NatLabRockies/OpenStudio-server/pull/818
 * remove URBANopt until 3.10.1 bc of gem conflicts
 * webpage fix https://github.com/NatLabRockies/OpenStudio-server/pull/819
@@ -17,6 +19,7 @@ Version 3.10.0
 * upgrade from Rails 6 to Rails 7, Mongoid 8.1, Puma 6.6 and remove webrick https://github.com/NatLabRockies/OpenStudio-server/pull/825
 * Local Server startup enhancements for PAT https://github.com/NatLabRockies/OpenStudio-server/pull/827
 
+  
 Version 3.9.0
 -------------
 * 3.9.0 was pulled and several RCs were tried to fix various issues.  This was the last RC before we ran out of funding for the release cycle.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install required libaries.
 #   realpath - needed for wait-for-it
 RUN apt-get update && apt-get install -y --no-install-recommends gnupg lsb-release \
-    && curl -fsSLk https://pgp.mongodb.com/server-6.0.asc -o /tmp/mongodb-server-6.0.asc \
-    && gpg --batch --show-keys --with-colons /tmp/mongodb-server-6.0.asc | grep -q '^fpr:::::::::4B0752C1BCA238C0B4EE14DC41DE058A4E7DCA05:' \
-    && gpg --batch --yes --dearmor -o /usr/share/keyrings/mongodb-org-6.0-archive-keyring.gpg /tmp/mongodb-server-6.0.asc \
-    && echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-org-6.0-archive-keyring.gpg] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
+    && curl -fsSLk https://pgp.mongodb.com/server-8.0.asc -o /tmp/mongodb-server-8.0.asc \
+    && gpg --batch --show-keys --with-colons /tmp/mongodb-server-8.0.asc | grep -q '^fpr:::::::::4B0752C1BCA238C0B4EE14DC41DE058A4E7DCA05:' \
+    && gpg --batch --yes --dearmor -o /usr/share/keyrings/mongodb-org-8.0-archive-keyring.gpg /tmp/mongodb-server-8.0.asc \
+    && echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-org-8.0-archive-keyring.gpg] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/8.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         mongodb-org \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fundamentals.
 
 The [openstudio_meta](./bin/openstudio_meta) file is a ruby script which provides access to packaging and execution 
 commands which allow for this codebase to be embedded in applications deployed to computers without docker. Deployment 
-requires that [MongoDB 6.0.12](https://www.mongodb.com/download-center/community/releases/archive) and [Ruby v3.2](https://www.ruby-lang.org/en/downloads/) 
+requires that [MongoDB 8.0.12](https://www.mongodb.com/download-center/community/releases/archive) and [Ruby v3.2](https://www.ruby-lang.org/en/downloads/) 
 are additionally packaged. 
 
 The openstudio_meta deployment relies on the `install_gems` command, which uses local system libraries to build all 

--- a/ci/github-actions/install_openstudio.sh
+++ b/ci/github-actions/install_openstudio.sh
@@ -8,7 +8,7 @@ OPENSTUDIO_VERSION_EXT="${3:-}"
 
 if [ ! -z ${OPENSTUDIO_VERSION} ] && [ ! -z ${OPENSTUDIO_SHA} ]; then
     # OPENSTUDIO_VERSION_EXT may be empty
-    OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}+${OPENSTUDIO_SHA}-Ubuntu-22.04-x86_64.deb
+    OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}+${OPENSTUDIO_SHA}-Ubuntu-24.04-x86_64.deb
     echo "Installing OpenStudio ${OPENSTUDIO_DOWNLOAD_FILENAME}"
     #OPENSTUDIO_DOWNLOAD_BASE_URL=https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop
     #OPENSTUDIO_DOWNLOAD_BASE_URL=https://github.com/NatLabRockies/OpenStudio/releases/download/v3.8.0

--- a/ci/github-actions/setup.sh
+++ b/ci/github-actions/setup.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 echo "The build architecture is ${ImageOS}"
 
-if [ "${ImageOS}" == "ubuntu22" ] && [ "${BUILD_TYPE}" == "docker" ]; then
+if [ "${ImageOS}" == "ubuntu24" ] && [ "${BUILD_TYPE}" == "docker" ]; then
     echo "Installing docker compose"
     sudo rm -f /usr/local/bin/docker-compose
     curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
@@ -14,7 +14,7 @@ if [ "${ImageOS}" == "ubuntu22" ] && [ "${BUILD_TYPE}" == "docker" ]; then
 
 else
     # sudo rvm implode --force  # rvm PATH rewriting interferes with portable Ruby.
-    if [ "${ImageOS}" == "macos13" ]; then
+    if [ "${ImageOS}" == "macos15" ]; then
 
         brew update > $GITHUB_WORKSPACE/spec/files/logs/brew-update.log
         brew install pv tree coreutils shared-mime-info
@@ -33,14 +33,14 @@ else
         rm ruby-3.2.2-darwin.tar.gz
 
         # Install mongodb from a download. Brew is hanging and requires building mongo. This also speeds up the builds.
-        curl -SLO https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-6.0.12.tgz
-        tar xvzf mongodb-macos-x86_64-6.0.12.tgz
+        curl -SLO https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.0.12.tgz
+        tar xvzf mongodb-macos-x86_64-8.0.12.tgz
         exit_status_tar=$?
         if [ $exit_status_tar -ne 0 ]; then
-         echo "Error: Failed to extract Mongo 6.0.12 archive"
+         echo "Error: Failed to extract Mongo 8.0.12 archive"
          exit $exit_status_tar
         fi
-        sudo cp mongodb-macos-x86_64-6.0.12/bin/* /usr/local/bin/
+        sudo cp mongodb-macos-x86_64-8.0.12/bin/* /usr/local/bin/
         rm -r mongodb-macos*
 
         # Install openstudio -- Use the install script that is in this repo now, the one on OpenStudio/develop has changed
@@ -83,14 +83,14 @@ else
         ulimit -n 4096
         ulimit -a
 
-    elif [ "${ImageOS}" == "ubuntu22" ]; then
+    elif [ "${ImageOS}" == "ubuntu24" ]; then
         echo "Setting up Ubuntu for unit tests and Rubocop"
         # install pipe viewer to throttle printing logs to screen (not a big deal in linux, but it is in osx)
         sudo apt-get update && sudo apt-get install -y wget gnupg software-properties-common build-essential
         # Import MongoDB public GPG key
-        sudo wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor | sudo tee /usr/share/keyrings/mongodb-org-6.0-archive-keyring.gpg
+        sudo wget -qO - https://www.mongodb.org/static/pgp/server-8.0.asc | gpg --dearmor | sudo tee /usr/share/keyrings/mongodb-org-8.0-archive-keyring.gpg
         # Add MongoDB to the sources list
-        echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-org-6.0-archive-keyring.gpg] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+        echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-org-8.0-archive-keyring.gpg] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
 
         sudo apt-get update
         sudo apt-get install -y pv tree mongodb-org libqdbm14 libxml2-dev
@@ -112,8 +112,8 @@ else
         # install portable ruby - required for build that will eventually be published
         # see https://github.com/NatLabRockies/OpenStudio-PAT/wiki/Pat-Build-Notes
         #curl -SLO --insecure https://openstudio-resources.s3.amazonaws.com/pat-dependencies3/ruby-3.2.2-linux.tar.gz
-        curl -SLO --insecure https://openstudio-resources.s3.us-east-1.amazonaws.com/pat-dependencies3/ruby-3.2.2-ubuntu22.04-x86_64.tar.gz                             
-        tar xvzf ruby-3.2.2-ubuntu22.04-x86_64.tar.gz 
+        curl -SLO --insecure https://openstudio-resources.s3.us-east-1.amazonaws.com/pat-dependencies3/ruby-3.2.2-ubuntu24.04-x86_64.tar.gz                             
+        tar xvzf ruby-3.2.2-ubuntu24.04-x86_64.tar.gz 
         exit_status_tar=$?
         if [ $exit_status_tar -ne 0 ]; then
          echo "Error: Failed to extract Ruby 3.2.2 archive"
@@ -123,7 +123,7 @@ else
         sudo rm -rf /usr/local/ruby
         sudo mv ruby /usr/local/
         ldd /usr/local/ruby/bin/ruby
-        rm ruby-3.2.2-ubuntu22.04-x86_64.tar.gz 
+        rm ruby-3.2.2-ubuntu24.04-x86_64.tar.gz 
 
         mkdir -p reports/rspec
         sudo ./ci/github-actions/install_openstudio.sh $OPENSTUDIO_VERSION $OPENSTUDIO_VERSION_SHA $OPENSTUDIO_VERSION_EXT

--- a/ci/github-actions/test.sh
+++ b/ci/github-actions/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # platform-specific config here (also in setup.sh):
-if [ "${ImageOS}" == "macos13" ]; then
+if [ "${ImageOS}" == "macos15" ]; then
     # Dir containing openstudio
     export OS_NAME_WITH_PLUS=OpenStudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}+${OPENSTUDIO_VERSION_SHA}-Darwin-x86_64
     export RUBYLIB="$HOME/$OS_NAME_WITH_PLUS/Ruby"
@@ -11,7 +11,7 @@ if [ "${ImageOS}" == "macos13" ]; then
     export GEM_HOME="$GITHUB_WORKSPACE/gems"
     export GEM_PATH="$GITHUB_WORKSPACE/gems:$GITHUB_WORKSPACE/gems/bundler/gems"
     mongo_dir="/usr/local/bin"
-elif [ "${ImageOS}" == "ubuntu22" ]; then
+elif [ "${ImageOS}" == "ubuntu24" ]; then
     # Dir containing openstudio
     export ENERGYPLUS_EXE_PATH=/usr/local/openstudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}/EnergyPlus/energyplus
     export PATH=/usr/local/ruby/bin:/usr/bin:/usr/local/openstudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}/bin:${PATH}
@@ -83,14 +83,14 @@ else
 
         # Fix the shebang line in the bundle and bundler scripts
         echo "Fixing the shebang line in the bundle and bundler scripts"
-        if [ "${ImageOS}" == "macos13" ]; then
+        if [ "${ImageOS}" == "macos15" ]; then
             sed -i '' "1s|.*|#!${RUBY_PATH}|" $BUNDLE_PATH
         else
             sed -i "1s|.*|#!${RUBY_PATH}|" $BUNDLE_PATH
         fi
 
         # Remove additional lines added by RubyGems
-        if [ "${ImageOS}" == "macos13" ]; then
+        if [ "${ImageOS}" == "macos15" ]; then
             sed -i '' '/_=_\\/,/#!\/usr\/bin\/env ruby/d' $BUNDLE_PATH
         else
             sed -i '/_=_\\/,/#!\/usr\/bin\/env ruby/d' $BUNDLE_PATH

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,7 +1,7 @@
 # Version used to deploy the latest version of the server from docker hub.
 services:
   db:
-    image: mongo:6.0.12
+    image: mongo:8.0.12
     ports:
       - "27017:27017"
     deploy:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@
 # run `docker-compose up` to create and run/link the containers
 services:
   db:
-    image: mongo:6.0.12
+    image: mongo:8.0.12
     ports:
       - "27017:27017"
     volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@
 # run `docker-compose up` to create and run/link the containers
 services:
   db:
-    image: mongo:6.0.12
+    image: mongo:8.0.12
     ports:
       - "27017:27017"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # run `docker-compose up` to create and run/link the containers
 services:
   db:
-    image: mongo:6.0.12
+    image: mongo:8.0.12
     ports:
       - "27017:27017"
     volumes:

--- a/local_setup_scripts/nuke.sh
+++ b/local_setup_scripts/nuke.sh
@@ -15,7 +15,7 @@ echo "pull images"
 docker pull registry:2.6
 docker pull nrel/openstudio-server:$1
 docker pull nrel/openstudio-rserve:$1
-docker pull mongo:6.0.12
+docker pull mongo:8.0.12
 docker pull redis:6.0.9
 
 echo "create registry"
@@ -26,7 +26,7 @@ sleep 10
 echo "tag"
 docker tag nrel/openstudio-server:$1 127.0.0.1:5000/openstudio-server
 docker tag nrel/openstudio-rserve:$1 127.0.0.1:5000/openstudio-rserve
-docker tag mongo:6.0.12 127.0.0.1:5000/mongo
+docker tag mongo:8.0.12 127.0.0.1:5000/mongo
 docker tag redis:6.0.9 127.0.0.1:5000/redis
 sleep 3
 echo "push"

--- a/local_setup_scripts/rebuild_sr.sh
+++ b/local_setup_scripts/rebuild_sr.sh
@@ -12,8 +12,8 @@ cd docker/R/
 #docker image rm 127.0.0.1:5000/openstudio-rserve -f
 docker build . -t="127.0.0.1:5000/openstudio-rserve"
 docker push 127.0.0.1:5000/openstudio-rserve
-docker pull mongo:6.0.12
-docker tag mongo:6.0.12 127.0.0.1:5000/mongo
+docker pull mongo:8.0.12
+docker tag mongo:8.0.12 127.0.0.1:5000/mongo
 docker push 127.0.0.1:5000/mongo
 docker pull redis:6.0.9
 docker tag redis:6.0.9 127.0.0.1:5000/redis

--- a/local_setup_scripts/win64/docker-compose-amd64.yml
+++ b/local_setup_scripts/win64/docker-compose-amd64.yml
@@ -1,7 +1,7 @@
 services:
   db:
     platform: linux/arm64
-    image: mongo:6.0.12
+    image: mongo:8.0.12
     ports:
       - "27017:27017"
     volumes:

--- a/local_setup_scripts/win64/docker-compose-local.yml
+++ b/local_setup_scripts/win64/docker-compose-local.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mongo:6.0.12
+    image: mongo:8.0.12
     ports:
       - "27017:27017"
     volumes:

--- a/local_setup_scripts/win64/nuke.ps1
+++ b/local_setup_scripts/win64/nuke.ps1
@@ -15,8 +15,8 @@ echo "pull images"
 docker pull registry:2.6
 docker pull nrel/openstudio-server:$Args
 docker pull nrel/openstudio-rserve:$Args
-docker pull mongo:6.0.12
-docker pull redis:6.0.9
+docker pull mongo:8.0.12
+docker pull redis:4.0.6
 
 echo "create registry"
 docker volume create --name=regdata
@@ -26,8 +26,8 @@ sleep 10
 echo "tag"
 docker tag nrel/openstudio-server:$Args 127.0.0.1:5000/openstudio-server
 docker tag nrel/openstudio-rserve:$Args 127.0.0.1:5000/openstudio-rserve
-docker tag mongo:6.0.12 127.0.0.1:5000/mongo
-docker tag redis:6.0.9 127.0.0.1:5000/redis
+docker tag mongo:8.0.12 127.0.0.1:5000/mongo
+docker tag redis:4.0.6 127.0.0.1:5000/redis
 sleep 3
 echo "push"
 docker push 127.0.0.1:5000/openstudio-server

--- a/local_setup_scripts/win64/nuke.sh
+++ b/local_setup_scripts/win64/nuke.sh
@@ -15,7 +15,7 @@ echo "pull images"
 docker pull registry:2.6
 docker pull nrel/openstudio-server:$1
 docker pull nrel/openstudio-rserve:$1
-docker pull mongo:6.0.12
+docker pull mongo:8.0.12
 docker pull redis:6.0.9
 
 echo "create registry"
@@ -26,7 +26,7 @@ sleep 10
 echo "tag"
 docker tag nrel/openstudio-server:$1 127.0.0.1:5000/openstudio-server
 docker tag nrel/openstudio-rserve:$1 127.0.0.1:5000/openstudio-rserve
-docker tag mongo:6.0.12 127.0.0.1:5000/mongo
+docker tag mongo:8.0.12 127.0.0.1:5000/mongo
 docker tag redis:6.0.9 127.0.0.1:5000/redis
 sleep 3
 echo "push"

--- a/local_setup_scripts/win64/rebuild_sr.sh
+++ b/local_setup_scripts/win64/rebuild_sr.sh
@@ -12,8 +12,8 @@ cd docker/R
 docker image rm 127.0.0.1:5000/openstudio-rserve -f
 docker build --no-cache . -t="127.0.0.1:5000/openstudio-rserve"
 docker push 127.0.0.1:5000/openstudio-rserve
-docker pull mongo:6.0.12
-docker tag mongo:6.0.12 127.0.0.1:5000/mongo
+docker pull mongo:8.0.12
+docker tag mongo:8.0.12 127.0.0.1:5000/mongo
 docker push 127.0.0.1:5000/mongo
 docker pull redis:6.0.9
 docker tag redis:6.0.9 127.0.0.1:5000/redis

--- a/local_setup_scripts/win64/rebuild_sr_no_rm.sh
+++ b/local_setup_scripts/win64/rebuild_sr_no_rm.sh
@@ -12,8 +12,8 @@ cd docker/R
 #docker image rm 127.0.0.1:5000/openstudio-rserve -f
 #docker build . -t="127.0.0.1:5000/openstudio-rserve"
 docker push 127.0.0.1:5000/openstudio-rserve
-docker pull mongo:6.0.12
-docker tag mongo:6.0.12 127.0.0.1:5000/mongo
+docker pull mongo:8.0.12
+docker tag mongo:8.0.12 127.0.0.1:5000/mongo
 docker push 127.0.0.1:5000/mongo
 docker pull redis:6.0.9
 docker tag redis:6.0.9 127.0.0.1:5000/redis

--- a/local_setup_scripts/win64/rebuild_sr_no_rm_mock.sh
+++ b/local_setup_scripts/win64/rebuild_sr_no_rm_mock.sh
@@ -12,8 +12,8 @@ cd docker/R
 #docker image rm 127.0.0.1:5000/openstudio-rserve -f
 docker build . -t="127.0.0.1:5000/openstudio-rserve"
 docker push 127.0.0.1:5000/openstudio-rserve
-docker pull mongo:6.0.12
-docker tag mongo:6.0.12 127.0.0.1:5000/mongo
+docker pull mongo:8.0.12
+docker tag mongo:8.0.12 127.0.0.1:5000/mongo
 docker push 127.0.0.1:5000/mongo
 docker pull redis:6.0.9
 docker tag redis:6.0.9 127.0.0.1:5000/redis

--- a/server/spec/features/docker_stack_requeue_spec.rb
+++ b/server/spec/features/docker_stack_requeue_spec.rb
@@ -109,6 +109,43 @@ RSpec.describe 'RunRequeue', type: :feature, algo: true do
             electricity_consumption_nmbe: -82.94121,
             natural_gas_consumption_cvrmse: 69.4762,
             natural_gas_consumption_nmbe: -50.88541
+           },
+           # OpenStudio 3.10.0 results
+           {
+            electricity_consumption_cvrmse: 11.80643639,
+            electricity_consumption_nmbe: -9.992706452,
+            natural_gas_consumption_cvrmse: 88.97549886,
+            natural_gas_consumption_nmbe: -71.2422889
+           },
+           {
+            electricity_consumption_cvrmse: 22.26135019,
+            electricity_consumption_nmbe: 21.07474074,
+            natural_gas_consumption_cvrmse: 123.6693321,
+            natural_gas_consumption_nmbe: 89.28433483
+           },
+           {
+            electricity_consumption_cvrmse: 19.92877245,
+            electricity_consumption_nmbe: -19.20285379,
+            natural_gas_consumption_cvrmse: 81.09035156,
+            natural_gas_consumption_nmbe: -61.5710272
+           },
+           {
+            electricity_consumption_cvrmse: 41.31502887,
+            electricity_consumption_nmbe: -41.6127891,
+            natural_gas_consumption_cvrmse: 99.892904,
+            natural_gas_consumption_nmbe: 70.79385513
+           },
+           {
+            electricity_consumption_cvrmse: 55.38893763588019,
+            electricity_consumption_nmbe: -57.11056265094546,
+            natural_gas_consumption_cvrmse: 43.52243818,
+            natural_gas_consumption_nmbe: 22.80778241
+           },
+           {
+            electricity_consumption_cvrmse: 80.27419288,
+            electricity_consumption_nmbe: -83.30621751,
+            natural_gas_consumption_cvrmse: 69.47538644,
+            natural_gas_consumption_nmbe: -50.88411437
            }]
     
     # setup bad results
@@ -294,6 +331,25 @@ RSpec.describe 'RunRequeue', type: :feature, algo: true do
             electricity_consumption_nmbe: -89.3516,
             natural_gas_consumption_cvrmse: 59.58792,
             natural_gas_consumption_nmbe: 37.55463
+           },
+           # OpenStudio 3.10.0 results
+           {
+            electricity_consumption_cvrmse: 45.748727859310684,
+            electricity_consumption_nmbe: -47.15331592,
+            natural_gas_consumption_cvrmse: 93.87522319797985,
+            natural_gas_consumption_nmbe: -76.99356458
+           },
+           {
+            electricity_consumption_cvrmse: 36.992082716685594,
+            electricity_consumption_nmbe: 36.75558058301333,
+            natural_gas_consumption_cvrmse: 26.054394017956753,
+            natural_gas_consumption_nmbe: -1.974857387
+           },
+           {
+            electricity_consumption_cvrmse: 88.15691010253096,
+            electricity_consumption_nmbe: -90.09381264,
+            natural_gas_consumption_cvrmse: 59.5879904,
+            natural_gas_consumption_nmbe: 37.55474192165185
            }]
     
     # setup bad results


### PR DESCRIPTION
Reworks 18b3457b so branch `179` downgrades **only OpenStudio** (3.11.0 → 3.10.0, SHA `241b8abb4d` → `86d7e215a1`). The runner/platform downgrades that came with it were unnecessary — the [v3.10.0 release](https://github.com/NatLabRockies/OpenStudio/releases/tag/v3.10.0) ships `Ubuntu-24.04-x86_64` and `Darwin-x86_64` packages with the exact pinned SHA — and they broke CI three ways:

1. **Missing Ruby tarball**: setup pointed at `ruby-3.2.2-ubuntu22.04-x86_64.tar.gz`, which doesn't exist in the S3 bucket (403). The ubuntu24.04 tarball develop uses is live.
2. **Retired runner**: `macos-13` GitHub-hosted runners no longer exist — that job could never start.
3. **Broken key pin**: the Dockerfile switched to the MongoDB 6.0 key URL but kept the 8.0 fingerprint pin (`4B0752C1…`), so the image build dies at the pin check (6.0's fingerprint is `39BD841E…C3C388`).

## What this PR does
- Reverts runners to `ubuntu-24.04` / `macos-15-intel`, MongoDB back to 8.x everywhere (Dockerfile, compose files, CI setup, local scripts, README), Ruby tarball back to `ubuntu24.04` — i.e., develop's state.
- Keeps the OpenStudio 3.10.0 pin across workflows env, Dockerfile ARG, `version.rb`, appveyor, deploy script, docs, terraform, and local scripts.
- Keeps the `workflow_dispatch` trigger (still the only way to run CI on branch `179` — it matches no push filter and had zero runs).
- CHANGELOG: folds the 3.11.0 section into 3.10.0, keeping the still-true infra bullets (Ubuntu 24.04, macOS 15, Mongo 8) and noting the OpenStudio pin.

## Verification (local)
- Docker image builds clean from the corrected Dockerfile (`nrel/openstudio:3.10.0` base).
- Inside the image: `openstudio openstudio_version` → `3.10.0+86d7e215a1`, `mongod --version` → `v8.0.28`.
- All CI download URLs verified 200: 3.10.0 Ubuntu-24.04 deb/tar.gz and `ruby-3.2.2-ubuntu24.04-x86_64.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)