### PR TITLE
Fix initialize_worker lock for NFS

### DIFF
--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -10,6 +10,7 @@ module DjJobs
     include DjJobs::UrbanOpt
     require 'date'
     require 'json'
+    require 'securerandom'
 
     MAX_INLINE_SDP_LOG_BYTES = 5_000_000
     MAX_INLINE_SDP_LOG_LINES = 5_000
@@ -421,7 +422,8 @@ module DjJobs
         @sim_logger.warn "initialize_worker_timeout option: #{@data_point.analysis.initialize_worker_timeout} is not valid.  Using 28800s instead."
         @data_point.analysis.initialize_worker_timeout = 28800
       end
-      # This block makes this code threadsafe for non-docker deployments, i.e. desktop usage
+      # Keep the receipt file as the handoff signal. Redis provides the cross-host lease
+      # when available; the file-lock fallback remains for local-only environments.
       if File.exist? write_lock_file
         @sim_logger.info 'write_lock_file exists, checking & waiting for receipt file'
 
@@ -433,6 +435,7 @@ module DjJobs
         # never come just wastes a worker slot for no reason.
         lock_holder_gone = false
         abandoned_probes = 0
+        redis_lock = redis_lock_client
         begin
           Timeout.timeout(@data_point.analysis.initialize_worker_timeout) do
             loop do
@@ -443,13 +446,22 @@ module DjJobs
                 break
               end
 
-              # flock is released by the OS when its holder dies, even on SIGKILL/OOM -
-              # deaths write_lock's own rescue cleanup never sees. A lock file whose flock
-              # is acquirable is abandoned; detect that here instead of waiting out the
-              # full initialize_worker_timeout. Require two consecutive positive probes
-              # (a poll interval apart) so a holder's open->flock startup gap can never
-              # read as abandonment.
-              if lock_abandoned?(write_lock_file)
+              # Redis-backed leases are the cross-host coordination path. Keep the
+              # existing two-probe guard so a brief lease handoff cannot be mistaken
+              # for abandonment.
+              if redis_lock
+                if redis_lock_active?(write_lock_file)
+                  abandoned_probes = 0
+                else
+                  abandoned_probes += 1
+                  if abandoned_probes >= 2
+                    @sim_logger.error 'write_lock_file exists but its Redis lease is gone; the original holder died without cleaning up. Clearing the abandoned lock and failing this attempt so it can be retried.'
+                    FileUtils.rm_f write_lock_file
+                    lock_holder_gone = true
+                    break
+                  end
+                end
+              elsif lock_abandoned?(write_lock_file)
                 abandoned_probes += 1
                 if abandoned_probes >= 2
                   @sim_logger.error 'write_lock_file exists but its flock is not held; the original holder died without cleaning up. Clearing the abandoned lock and failing this attempt so it can be retried.'
@@ -471,7 +483,14 @@ module DjJobs
           # initialize_worker_timeout, so it can legitimately outlive this single wait)
           # still owns the file, and deleting it would let a third worker re-create the
           # lock on a new inode and initialize the same analysis_dir concurrently.
-          if lock_abandoned?(write_lock_file)
+          if redis_lock
+            if redis_lock_active?(write_lock_file)
+              @sim_logger.error "Required analysis objects were not retrieved after #{@data_point.analysis.initialize_worker_timeout} seconds; the Redis lease is still active, leaving its lock in place."
+            else
+              @sim_logger.error "Required analysis objects were not retrieved after #{@data_point.analysis.initialize_worker_timeout} seconds and the Redis lease is gone; clearing the stale lock so a future worker does not wait on it."
+              FileUtils.rm_f write_lock_file
+            end
+          elsif lock_abandoned?(write_lock_file)
             @sim_logger.error "Required analysis objects were not retrieved after #{@data_point.analysis.initialize_worker_timeout} seconds and the lock is not held; clearing the stale lock so a future worker does not wait on it."
             FileUtils.rm_f write_lock_file
           else
@@ -636,28 +655,103 @@ module DjJobs
       true
     end
 
-    def write_lock(lock_file_path)
-      lock_file = File.open(lock_file_path, 'a')
-      begin
-        lock_file.flock(File::LOCK_EX)
-        lock_file << Time.now
+    def redis_lock_client
+      return nil unless defined?(Resque) && Resque.respond_to?(:redis)
 
-        yield
-      rescue StandardError
-        # The protected block failed before a receipt file could be written. Delete the lock
-        # file (not just release the flock) so a future attempt does not see a stale lock and
-        # wait up to initialize_worker_timeout (default 8h) for a receipt that will never come.
-        # Unlock and close BEFORE deleting: Windows (the desktop/PAT deployment this lock
-        # exists for) cannot unlink an open file, and FileUtils.rm_f swallows that failure
-        # silently, leaving the stale lock - and the deadlock - in place.
-        lock_file.flock(File::LOCK_UN)
-        lock_file.close
-        FileUtils.rm_f lock_file_path
-        raise
-      ensure
-        unless lock_file.closed?
+      redis = Resque.redis
+      return redis if redis.respond_to?(:set) && redis.respond_to?(:exists?) && redis.respond_to?(:get) && redis.respond_to?(:pexpire) && redis.respond_to?(:eval)
+
+      nil
+    rescue StandardError
+      nil
+    end
+
+    def redis_lock_key(lock_file_path)
+      "analysis_zip.lock:#{File.basename(File.dirname(lock_file_path))}"
+    end
+
+    def redis_lock_ttl_ms
+      120_000
+    end
+
+    def redis_lock_active?(lock_file_path)
+      redis = redis_lock_client
+      return false unless redis
+
+      redis.exists?(redis_lock_key(lock_file_path)).to_i.positive?
+    end
+
+    def acquire_redis_lock(redis, lock_file_path)
+      lock_key = redis_lock_key(lock_file_path)
+      lock_token = SecureRandom.uuid
+      return nil unless redis.set(lock_key, lock_token, nx: true, px: redis_lock_ttl_ms)
+
+      renewal_thread = Thread.new do
+        loop do
+          sleep redis_lock_ttl_ms / 2000
+          break unless redis.get(lock_key) == lock_token
+
+          redis.pexpire(lock_key, redis_lock_ttl_ms)
+        end
+      end
+
+      [lock_key, lock_token, renewal_thread]
+    end
+
+    def release_redis_lock(redis, lock_key, lock_token, renewal_thread)
+      renewal_thread&.kill
+      renewal_thread&.join
+
+      redis.eval(<<~LUA, [lock_key], [lock_token])
+        if redis.call('get', KEYS[1]) == ARGV[1] then
+          return redis.call('del', KEYS[1])
+        end
+
+        return 0
+      LUA
+    rescue StandardError => e
+      @sim_logger&.warn "Could not release Redis lock #{lock_key}: #{e.message}"
+    end
+
+    def write_lock(lock_file_path)
+      redis = redis_lock_client
+      if redis
+        lock_data = acquire_redis_lock(redis, lock_file_path)
+        raise "Could not acquire Redis lock for #{lock_file_path}" unless lock_data
+
+        lock_key, lock_token, renewal_thread = lock_data
+        begin
+          File.open(lock_file_path, 'a') { |lock_file| lock_file << Time.now }
+          yield
+        rescue StandardError
+          FileUtils.rm_f lock_file_path
+          raise
+        ensure
+          release_redis_lock(redis, lock_key, lock_token, renewal_thread)
+        end
+      else
+        lock_file = File.open(lock_file_path, 'a')
+        begin
+          lock_file.flock(File::LOCK_EX)
+          lock_file << Time.now
+
+          yield
+        rescue StandardError
+          # The protected block failed before a receipt file could be written. Delete the lock
+          # file (not just release the flock) so a future attempt does not see a stale lock and
+          # wait up to initialize_worker_timeout (default 8h) for a receipt that will never come.
+          # Unlock and close BEFORE deleting: Windows (the desktop/PAT deployment this lock
+          # exists for) cannot unlink an open file, and FileUtils.rm_f swallows that failure
+          # silently, leaving the stale lock - and the deadlock - in place.
           lock_file.flock(File::LOCK_UN)
           lock_file.close
+          FileUtils.rm_f lock_file_path
+          raise
+        ensure
+          unless lock_file.closed?
+            lock_file.flock(File::LOCK_UN)
+            lock_file.close
+          end
         end
       end
     end

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -450,7 +450,7 @@ module DjJobs
               # existing two-probe guard so a brief lease handoff cannot be mistaken
               # for abandonment.
               if redis_lock
-                if redis_lock_active?(write_lock_file)
+                if redis_lock_active?(redis_lock, write_lock_file)
                   abandoned_probes = 0
                 else
                   abandoned_probes += 1
@@ -461,6 +461,11 @@ module DjJobs
                     break
                   end
                 end
+              elsif redis_backed_lock_file?(write_lock_file)
+                # We cannot safely infer abandonment from flock when this lock file was
+                # created by the Redis lease path (no flock is held). Treat Redis
+                # unavailability as indeterminate and wait for receipt/timeout.
+                abandoned_probes = 0
               elsif lock_abandoned?(write_lock_file)
                 abandoned_probes += 1
                 if abandoned_probes >= 2
@@ -484,12 +489,14 @@ module DjJobs
           # still owns the file, and deleting it would let a third worker re-create the
           # lock on a new inode and initialize the same analysis_dir concurrently.
           if redis_lock
-            if redis_lock_active?(write_lock_file)
+            if redis_lock_active?(redis_lock, write_lock_file)
               @sim_logger.error "Required analysis objects were not retrieved after #{@data_point.analysis.initialize_worker_timeout} seconds; the Redis lease is still active, leaving its lock in place."
             else
               @sim_logger.error "Required analysis objects were not retrieved after #{@data_point.analysis.initialize_worker_timeout} seconds and the Redis lease is gone; clearing the stale lock so a future worker does not wait on it."
               FileUtils.rm_f write_lock_file
             end
+          elsif redis_backed_lock_file?(write_lock_file)
+            @sim_logger.error "Required analysis objects were not retrieved after #{@data_point.analysis.initialize_worker_timeout} seconds; Redis is unavailable and this lock looks Redis-backed, so abandonment cannot be determined safely. Leaving the lock in place."
           elsif lock_abandoned?(write_lock_file)
             @sim_logger.error "Required analysis objects were not retrieved after #{@data_point.analysis.initialize_worker_timeout} seconds and the lock is not held; clearing the stale lock so a future worker does not wait on it."
             FileUtils.rm_f write_lock_file
@@ -674,11 +681,18 @@ module DjJobs
       120_000
     end
 
-    def redis_lock_active?(lock_file_path)
-      redis = redis_lock_client
-      return false unless redis
-
+    def redis_lock_active?(redis, lock_file_path)
       redis.exists?(redis_lock_key(lock_file_path)).to_i.positive?
+    end
+
+    def redis_backed_lock_file?(lock_file_path)
+      return false unless File.exist?(lock_file_path)
+
+      File.open(lock_file_path, 'r') do |f|
+        f.read(256).to_s.include?('redis-lock:')
+      end
+    rescue StandardError
+      false
     end
 
     def acquire_redis_lock(redis, lock_file_path)
@@ -686,21 +700,48 @@ module DjJobs
       lock_token = SecureRandom.uuid
       return nil unless redis.set(lock_key, lock_token, nx: true, px: redis_lock_ttl_ms)
 
+      renewal_state = { stop: false, failed: false, last_renewed_at: Process.clock_gettime(Process::CLOCK_MONOTONIC) }
       renewal_thread = Thread.new do
+        backoff_seconds = 1
         loop do
-          sleep redis_lock_ttl_ms / 2000
-          break unless redis.get(lock_key) == lock_token
+          sleep redis_lock_ttl_ms / 2000.0
+          break if renewal_state[:stop]
 
-          redis.pexpire(lock_key, redis_lock_ttl_ms)
+          begin
+            unless redis.get(lock_key) == lock_token
+              renewal_state[:failed] = true
+              @sim_logger&.error "Redis lease token for #{lock_key} changed while holding write lock; aborting lease renewal."
+              break
+            end
+
+            redis.pexpire(lock_key, redis_lock_ttl_ms)
+            renewal_state[:last_renewed_at] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            backoff_seconds = 1
+          rescue StandardError => e
+            @sim_logger&.warn "Redis lease renewal failed for #{lock_key}: #{e.message}"
+            if Process.clock_gettime(Process::CLOCK_MONOTONIC) - renewal_state[:last_renewed_at] > (redis_lock_ttl_ms / 1000.0)
+              renewal_state[:failed] = true
+              @sim_logger&.error "Redis lease for #{lock_key} has not been renewed within TTL; aborting lease renewal."
+              break
+            end
+
+            sleep backoff_seconds
+            backoff_seconds = [backoff_seconds * 2, 5].min
+          end
         end
       end
 
-      [lock_key, lock_token, renewal_thread]
+      [lock_key, lock_token, renewal_thread, renewal_state]
     end
 
-    def release_redis_lock(redis, lock_key, lock_token, renewal_thread)
-      renewal_thread&.kill
-      renewal_thread&.join
+    def release_redis_lock(redis, lock_key, lock_token, renewal_thread, renewal_state)
+      if renewal_state
+        renewal_state[:stop] = true
+      end
+      if renewal_thread
+        renewal_thread.join(2)
+        @sim_logger&.warn "Redis lease renewal thread for #{lock_key} did not stop within 2s; continuing with best-effort lock release." if renewal_thread.alive?
+      end
 
       redis.eval(<<~LUA, [lock_key], [lock_token])
         if redis.call('get', KEYS[1]) == ARGV[1] then
@@ -709,8 +750,10 @@ module DjJobs
 
         return 0
       LUA
+      renewal_state && renewal_state[:failed]
     rescue StandardError => e
       @sim_logger&.warn "Could not release Redis lock #{lock_key}: #{e.message}"
+      true
     end
 
     def write_lock(lock_file_path)
@@ -719,15 +762,21 @@ module DjJobs
         lock_data = acquire_redis_lock(redis, lock_file_path)
         raise "Could not acquire Redis lock for #{lock_file_path}" unless lock_data
 
-        lock_key, lock_token, renewal_thread = lock_data
+        lock_key, lock_token, renewal_thread, renewal_state = lock_data
         begin
-          File.open(lock_file_path, 'a') { |lock_file| lock_file << Time.now }
-          yield
+          File.open(lock_file_path, 'a') { |lock_file| lock_file << "redis-lock:#{lock_token} #{Time.now}\n" }
+          result = yield
+          raise "Redis lock renewal failed for #{lock_file_path}; aborting to avoid concurrent initialization." if renewal_state[:failed]
+
+          result
         rescue StandardError
           FileUtils.rm_f lock_file_path
           raise
         ensure
-          release_redis_lock(redis, lock_key, lock_token, renewal_thread)
+          renewal_failed = release_redis_lock(redis, lock_key, lock_token, renewal_thread, renewal_state)
+          if renewal_failed && !$!
+            raise "Redis lock renewal failed for #{lock_file_path}; protected work must be retried."
+          end
         end
       else
         lock_file = File.open(lock_file_path, 'a')

--- a/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
+++ b/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
         lock_path = File.join(dir, 'analysis_zip.lock')
         lock_key = "analysis_zip.lock:#{File.basename(File.dirname(lock_path))}"
         fake_redis = instance_double('Redis')
-        renewal_thread = instance_double(Thread, kill: nil, join: nil)
+        renewal_thread = instance_double(Thread, join: nil, alive?: false)
         job = described_class.allocate
 
         allow(job).to receive(:redis_lock_client).and_return(fake_redis)
@@ -190,6 +190,21 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
       expect(result).to be false
       expect(File.exist?(write_lock_file)).to be false
       expect(File.exist?(receipt_file)).to be false
+    end
+
+    it 'does not delete a Redis-backed lock file when Redis is unavailable to this worker' do
+      analysis.initialize_worker_timeout = 1
+      analysis.save!
+
+      job = build_job(redis_lock_client: nil)
+      write_lock_file = File.join(job.send(:analysis_dir), 'analysis_zip.lock')
+      File.write(write_lock_file, 'redis-lock:deadbeef-token')
+      allow(job).to receive(:sleep)
+
+      result = job.initialize_worker
+
+      expect(result).to be false
+      expect(File.exist?(write_lock_file)).to be true
     end
   end
 

--- a/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
+++ b/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
@@ -47,8 +47,10 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
   let(:analysis) { Analysis.new(project_id: project.id).tap(&:save!) }
   let(:data_point) { DataPoint.new(analysis_id: analysis.id).tap(&:save!) }
 
-  def build_job
-    described_class.new(data_point.id)
+  def build_job(redis_lock_client: nil)
+    job = described_class.new(data_point.id)
+    allow(job).to receive(:redis_lock_client).and_return(redis_lock_client)
+    job
   end
 
   describe '#initialize_worker with a stale/abandoned analysis_zip.lock' do
@@ -127,6 +129,8 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
     it 'removes the lock file (not just releasing the flock) when the protected block raises' do
       Dir.mktmpdir do |dir|
         lock_path = File.join(dir, 'analysis_zip.lock')
+        job = described_class.allocate
+        allow(job).to receive(:redis_lock_client).and_return(nil)
 
         expect { job.write_lock(lock_path) { raise 'boom' } }.to raise_error('boom')
         expect(File.exist?(lock_path)).to be false
@@ -136,12 +140,56 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
     it 'leaves the lock file in place when the protected block succeeds (only the flock is released)' do
       Dir.mktmpdir do |dir|
         lock_path = File.join(dir, 'analysis_zip.lock')
+        job = described_class.allocate
+        allow(job).to receive(:redis_lock_client).and_return(nil)
 
         result = job.write_lock(lock_path) { 'downloaded ok' }
 
         expect(result).to eq 'downloaded ok'
         expect(File.exist?(lock_path)).to be true
       end
+    end
+
+    it 'uses a Redis lease when one is available' do
+      Dir.mktmpdir do |dir|
+        lock_path = File.join(dir, 'analysis_zip.lock')
+        lock_key = "analysis_zip.lock:#{File.basename(File.dirname(lock_path))}"
+        fake_redis = instance_double('Redis')
+        renewal_thread = instance_double(Thread, kill: nil, join: nil)
+        job = described_class.allocate
+
+        allow(job).to receive(:redis_lock_client).and_return(fake_redis)
+        allow(Thread).to receive(:new).and_return(renewal_thread)
+        expect(fake_redis).to receive(:set).with(lock_key, kind_of(String), nx: true, px: 120_000).and_return(true)
+        expect(fake_redis).to receive(:eval).with(kind_of(String), [lock_key], kind_of(Array)).and_return(1)
+
+        result = job.write_lock(lock_path) { 'downloaded ok' }
+
+        expect(result).to eq 'downloaded ok'
+        expect(File.exist?(lock_path)).to be true
+      end
+    end
+  end
+
+  describe '#initialize_worker with a Redis-backed lock' do
+    it 'treats an expired Redis lease as abandoned and clears the stale lock file' do
+      analysis.initialize_worker_timeout = 20
+      analysis.save!
+
+      fake_redis = instance_double('Redis')
+      job = build_job(redis_lock_client: fake_redis)
+      write_lock_file = File.join(job.send(:analysis_dir), 'analysis_zip.lock')
+      receipt_file = File.join(job.send(:analysis_dir), 'analysis_zip.receipt')
+      File.write(write_lock_file, 'held by a redis-backed worker')
+
+      allow(job).to receive(:sleep)
+      allow(fake_redis).to receive(:exists?).and_return(0, 0)
+
+      result = job.initialize_worker
+
+      expect(result).to be false
+      expect(File.exist?(write_lock_file)).to be false
+      expect(File.exist?(receipt_file)).to be false
     end
   end
 


### PR DESCRIPTION
## Summary\n- Replace the analysis zip coordination path with a Redis-backed lease when Redis is available\n- Keep the receipt-file handoff and file-lock fallback for local deployments\n- Add regression coverage for Redis-backed locking and stale-lock cleanup\n\nFixes #857