### PR TITLE
Fix analysis-zip corruption on shared-FS (k8s/NFS) deployments (#857); nginx keepalive/gzip (#864)

### DIFF
--- a/docker/server/nginx.conf
+++ b/docker/server/nginx.conf
@@ -16,11 +16,15 @@ http {
 
     include mime.types;
     default_type application/octet-stream;
-    gzip off;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_comp_level 6;
+    gzip_min_length 1000;
 
     access_log /dev/stdout;
     sendfile on;
-    keepalive_timeout 0;
+    keepalive_timeout 65;
 
     passenger_max_request_queue_size MAX_REQUESTS_SUB; # This is a reserved keyword for dynamic substitution
     passenger_max_pool_size MAX_POOL_SUB; # This is a reserved keyword for dynamic substitution

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -775,10 +775,12 @@ module DjJobs
         @sim_logger.info "Zip: Extracting #{f.name}"
         f_path = File.join(destination, f.name)
         FileUtils.mkdir_p(File.dirname(f_path))
-        if File.exist?(f_path)
+        if File.exist?(f_path) && !overwrite
           @sim_logger.warn "SKIPPED: #{f.name}, already existed."
         else
-          zf.extract(f, f_path)
+          # the block authorizes replacing an existing file - without it rubyzip
+          # raises Zip::DestinationFileExistsError instead of overwriting (issue #858)
+          zf.extract(f, f_path) { true }
         end
       end
     end

--- a/server/app/jobs/dj_jobs/run_simulate_data_point.rb
+++ b/server/app/jobs/dj_jobs/run_simulate_data_point.rb
@@ -490,8 +490,20 @@ module DjJobs
       else
         # Try to download the analysis zip, but first lock simultanious threads
         write_lock(write_lock_file) do |_|
+          # Re-check the receipt now that we hold the lock: a worker that passed the
+          # outer receipt check may acquire the lock only after the init winner
+          # completed and wrote the receipt. Without this, every such worker
+          # re-downloads and re-extracts over content other datapoints are actively
+          # reading (issue #857's N-worker re-download herd).
+          if File.exist?(receipt_file)
+            @sim_logger.info 'receipt_file appeared while waiting for the lock; skipping analysis download/extract'
+            next
+          end
+
           zip_download_count = 0
           zip_max_download_count = 12
+          zip_validation_failures = 0
+          zip_validation_failure_max = 3
           download_file = "#{analysis_dir}/analysis.zip"
           download_url = "#{APP_CONFIG['os_server_host_url']}/analyses/#{@data_point.analysis.id}/download_analysis_zip"
           @sim_logger.info "Downloading analysis zip from #{download_url}"
@@ -499,15 +511,47 @@ module DjJobs
           begin
             Timeout.timeout(@data_point.analysis.initialize_worker_timeout) do
               zip_download_count += 1
-              File.open(download_file, 'wb') do |saved_file|
-                # the following "open" is provided by open-uri
-                URI.open(download_url, 'rb') do |read_file|
-                  saved_file.write(read_file.read)
+              # Download to a private temp name and validate BEFORE renaming into the
+              # shared path: on multi-node deployments the served bytes can be
+              # truncated or otherwise transiently corrupt (issue #857), and
+              # extracting them used to escalate a transient fetch problem into a
+              # terminal CorruptAnalysisZip failure. The rename is atomic within the
+              # directory, so readers of analysis.zip never observe a partial file;
+              # the pid suffix keeps a concurrent initializer (should locking ever
+              # fail) writing to its own temp file instead of interleaving with ours.
+              download_tmp = "#{download_file}.#{Process.pid}.part"
+              begin
+                File.open(download_tmp, 'wb') do |saved_file|
+                  # the following "open" is provided by open-uri
+                  URI.open(download_url, 'rb') do |read_file|
+                    saved_file.write(read_file.read)
+                  end
                 end
+                zip_error = Analysis.seed_zip_error(download_tmp)
+                if zip_error
+                  zip_validation_failures += 1
+                  # A transiently-corrupt transfer heals on retry; a corrupt-at-rest
+                  # zip fails validation identically every time. After
+                  # zip_validation_failure_max consecutive validation failures treat
+                  # the corruption as deterministic and fail terminally (issue #841
+                  # fail-fast semantics), sweeping partial content while still
+                  # holding the lock - same cleanup contract as the extract-stage
+                  # corrupt-zip rescue below.
+                  if zip_validation_failures >= zip_validation_failure_max
+                    FileUtils.rm_rf(Dir.glob("#{analysis_dir}/*") - [write_lock_file])
+                    raise CorruptAnalysisZip, "Analysis zip for datapoint #{@data_point.id} is corrupt and cannot be extracted: downloaded copy failed validation on #{zip_validation_failures} consecutive attempts: #{zip_error}"
+                  end
+                  raise "downloaded analysis zip failed validation (truncated or corrupt transfer): #{zip_error}"
+                end
+
+                FileUtils.mv(download_tmp, download_file)
+              ensure
+                FileUtils.rm_f download_tmp
               end
             end
           rescue StandardError => e
-            FileUtils.rm_f download_file if File.exist? download_file
+            raise if e.is_a?(CorruptAnalysisZip)
+
             sleep Random.new.rand(1.0..10.0)
             retry if zip_download_count < zip_max_download_count
             raise "Could not download the analysis zip after #{zip_max_download_count} attempts. Failed with message #{e.message}."
@@ -624,7 +668,13 @@ module DjJobs
     # LOCK_EX for its whole critical section, so LOCK_NB fails against it.
     def lock_abandoned?(lock_file_path)
       File.open(lock_file_path, 'r') do |f|
-        if f.flock(File::LOCK_EX | File::LOCK_NB)
+        # LOCK_SH, not LOCK_EX: over NFSv4 flock is emulated with byte-range locks,
+        # and an exclusive (write) probe on a fd opened read-only raises
+        # Errno::EBADF - so on the k8s/NFS deployments this probe crashed every
+        # waiter (issue #857). A shared probe is grantable on a read-only fd on
+        # every filesystem and is still blocked by a live holder's LOCK_EX, which
+        # is all the probe needs to distinguish held from abandoned.
+        if f.flock(File::LOCK_SH | File::LOCK_NB)
           f.flock(File::LOCK_UN)
           true
         else
@@ -634,6 +684,15 @@ module DjJobs
     rescue Errno::ENOENT
       # Deleted between our existence check and the open: holder is gone.
       true
+    rescue SystemCallError => e
+      # The probe itself failed (EBADF/ENOLCK/EIO on exotic network filesystems):
+      # abandonment cannot be determined, and the only safe reading is "held".
+      # Treating an indeterminate probe as abandoned deletes a LIVE holder's lock
+      # file, which lets the next worker re-create the lock on a new inode and
+      # initialize the same analysis_dir concurrently - the very corruption this
+      # probe exists to prevent.
+      @sim_logger&.warn "lock_abandoned? probe failed with #{e.class}: #{e.message}; treating lock as held"
+      false
     end
 
     def write_lock(lock_file_path)
@@ -704,17 +763,22 @@ module DjJobs
     # This is local function for workaround until that is resolved
     #OpenStudio::Workflow.extract_archive(download_file, analysis_dir)
     def extract_archive(archive_filename, destination, overwrite = true)
-      ::Zip.sort_entries = true
-      Zip::File.open(archive_filename) do |zf|
-        zf.each do |f|
-          @sim_logger.info "Zip: Extracting #{f.name}"
-          f_path = File.join(destination, f.name)
-          FileUtils.mkdir_p(File.dirname(f_path))
-          if File.exist?(f_path)
-            @sim_logger.warn "SKIPPED: #{f.name}, already existed."
-          else
-            zf.extract(f, f_path)
-          end
+      # Zip::File.new, NOT the Zip::File.open block form: open's implicit close calls
+      # commit, which REWRITES the archive in place (temp file + rename over the
+      # original) whenever the in-memory entry order differs from the stored order -
+      # which ::Zip.sort_entries = true guaranteed for any unsorted zip. On the shared
+      # analysis dir that rewrite races other workers downloading/extracting the same
+      # analysis.zip and corrupts it (issue #857). Sorting is irrelevant to extraction,
+      # and the global flag would poison every other Zip::File.open in this process.
+      zf = ::Zip::File.new(archive_filename)
+      zf.each do |f|
+        @sim_logger.info "Zip: Extracting #{f.name}"
+        f_path = File.join(destination, f.name)
+        FileUtils.mkdir_p(File.dirname(f_path))
+        if File.exist?(f_path)
+          @sim_logger.warn "SKIPPED: #{f.name}, already existed."
+        else
+          zf.extract(f, f_path)
         end
       end
     end

--- a/server/app/models/analysis.rb
+++ b/server/app/models/analysis.rb
@@ -517,17 +517,23 @@ class Analysis
   # This is local function for workaround until that is resolved
   # OpenStudio::Workflow.extract_archive(download_file, analysis_dir)
   def extract_archive(archive_filename, destination, overwrite = true)
-    ::Zip.sort_entries = true
-    Zip::File.open(archive_filename) do |zf|
-      zf.each do |f|
-        Rails.logger.debug "Extracting #{f.name}"
-        f_path = File.join(destination, f.name)
-        FileUtils.mkdir_p(File.dirname(f_path))
-        if File.exist?(f_path)
-          Rails.logger.debug "SKIPPED: #{f.name}, already existed."
-        else
-          zf.extract(f, f_path)
-        end
+    # Zip::File.new, NOT the Zip::File.open block form: open's implicit close calls
+    # commit, which REWRITES the archive in place (temp file + rename over the
+    # original) whenever the in-memory entry order differs from the stored order -
+    # which ::Zip.sort_entries = true guaranteed for any unsorted zip. This method
+    # extracts the LIVE seed_zip attachment at analysis start, exactly when workers
+    # download the same file via download_analysis_zip, so the rewrite raced (and
+    # corrupted) every fresh analysis's first datapoints on shared-filesystem
+    # deployments (issue #857). Same read-only rationale as seed_zip_error above.
+    zf = ::Zip::File.new(archive_filename)
+    zf.each do |f|
+      Rails.logger.debug "Extracting #{f.name}"
+      f_path = File.join(destination, f.name)
+      FileUtils.mkdir_p(File.dirname(f_path))
+      if File.exist?(f_path)
+        Rails.logger.debug "SKIPPED: #{f.name}, already existed."
+      else
+        zf.extract(f, f_path)
       end
     end
   end

--- a/server/app/models/analysis.rb
+++ b/server/app/models/analysis.rb
@@ -530,10 +530,12 @@ class Analysis
       Rails.logger.debug "Extracting #{f.name}"
       f_path = File.join(destination, f.name)
       FileUtils.mkdir_p(File.dirname(f_path))
-      if File.exist?(f_path)
+      if File.exist?(f_path) && !overwrite
         Rails.logger.debug "SKIPPED: #{f.name}, already existed."
       else
-        zf.extract(f, f_path)
+        # the block authorizes replacing an existing file - without it rubyzip
+        # raises Zip::DestinationFileExistsError instead of overwriting (issue #858)
+        zf.extract(f, f_path) { true }
       end
     end
   end

--- a/server/spec/models/analysis_init_spec.rb
+++ b/server/spec/models/analysis_init_spec.rb
@@ -173,6 +173,43 @@ RSpec.describe Analysis, type: :model do
     end
   end
 
+  # Regression specs for issue #858: the overwrite parameter was declared but never
+  # checked, so re-running initialization over a dir with stale/partial files silently
+  # kept the stale copies.
+  describe '#extract_archive overwrite behavior (issue #858)' do
+    def build_overwrite_zip(path)
+      Zip::OutputStream.open(path) do |zos|
+        zos.put_next_entry('data/seed.txt')
+        zos.write('fresh seed payload')
+      end
+      path
+    end
+
+    it 'replaces a pre-existing stale file with the archive contents by default' do
+      zip_path = build_overwrite_zip(File.join(@tmp_dir, 'overwrite_default.zip'))
+      dest = File.join(@tmp_dir, 'overwrite_default_dest')
+      stale_path = File.join(dest, 'data/seed.txt')
+      FileUtils.mkdir_p(File.dirname(stale_path))
+      File.write(stale_path, 'stale partial extraction')
+
+      @analysis.extract_archive(zip_path, dest)
+
+      expect(File.read(stale_path)).to eq('fresh seed payload'), 'overwrite defaults to true: stale pre-existing files must be replaced, not skipped'
+    end
+
+    it 'keeps a pre-existing file when overwrite is false' do
+      zip_path = build_overwrite_zip(File.join(@tmp_dir, 'overwrite_false.zip'))
+      dest = File.join(@tmp_dir, 'overwrite_false_dest')
+      existing_path = File.join(dest, 'data/seed.txt')
+      FileUtils.mkdir_p(File.dirname(existing_path))
+      File.write(existing_path, 'keep me')
+
+      @analysis.extract_archive(zip_path, dest, false)
+
+      expect(File.read(existing_path)).to eq('keep me')
+    end
+  end
+
   describe '#fail_job!' do
     it 'marks the newest job failed so the analysis reaches a terminal state' do
       # Regression: issue #841 - analyses with failed initialization sat in 'queued'

--- a/server/spec/models/analysis_init_spec.rb
+++ b/server/spec/models/analysis_init_spec.rb
@@ -147,6 +147,32 @@ RSpec.describe Analysis, type: :model do
     end
   end
 
+  describe '#extract_archive read-only behavior (issue #857)' do
+    it 'leaves the seed zip byte-identical after extraction' do
+      # Entries deliberately NOT in sorted order: with ::Zip.sort_entries = true, the
+      # Zip::File.open block form's implicit close called commit and REWROTE the archive
+      # in place (temp file + rename). run_initialization extracts the live seed_zip.path
+      # on the web-background node at analysis start - exactly when workers download the
+      # same file via download_analysis_zip - so that rewrite raced every fresh analysis's
+      # first datapoints on shared-filesystem deployments (issue #857).
+      zip_path = File.join(@tmp_dir, 'unsorted_seed.zip')
+      Zip::OutputStream.open(zip_path) do |zos|
+        zos.put_next_entry('zzz_last.txt')
+        zos.write('z' * 100)
+        zos.put_next_entry('aaa_first.txt')
+        zos.write('a' * 100)
+      end
+      before_md5 = Digest::MD5.file(zip_path).hexdigest
+      dest = File.join(@tmp_dir, 'extract_archive_dest')
+
+      @analysis.extract_archive(zip_path, dest)
+
+      expect(Digest::MD5.file(zip_path).hexdigest).to eq(before_md5), 'extract_archive must never modify the archive it reads'
+      expect(File.read(File.join(dest, 'aaa_first.txt'))).to eq('a' * 100)
+      expect(File.read(File.join(dest, 'zzz_last.txt'))).to eq('z' * 100)
+    end
+  end
+
   describe '#fail_job!' do
     it 'marks the newest job failed so the analysis reaches a terminal state' do
       # Regression: issue #841 - analyses with failed initialization sat in 'queued'

--- a/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
+++ b/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
@@ -273,6 +273,51 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
     end
   end
 
+  # Regression specs for issue #858: extract_archive declared an overwrite parameter but
+  # never checked it -- every existing file was skipped unconditionally. A worker killed
+  # mid-extract (rollout restart) leaves partial/stale files in the shared analysis dir;
+  # the next worker's extract must replace them, or OpenStudio's BCLMeasure loader chokes
+  # on the stale measure.xml ("could not be read as XML data").
+  describe '#extract_archive overwrite behavior (issue #858)' do
+    subject(:job) { described_class.allocate.tap { |j| j.instance_variable_set(:@sim_logger, Logger.new(nil)) } }
+
+    def build_measure_zip(path, xml)
+      Zip::OutputStream.open(path) do |zos|
+        zos.put_next_entry('measures/m1/measure.xml')
+        zos.write(xml)
+      end
+      path
+    end
+
+    it 'replaces a pre-existing stale file with the archive contents by default' do
+      Dir.mktmpdir do |dir|
+        zip_path = build_measure_zip(File.join(dir, 'analysis.zip'), '<measure>fresh</measure>')
+        dest = File.join(dir, 'dest')
+        stale_path = File.join(dest, 'measures/m1/measure.xml')
+        FileUtils.mkdir_p(File.dirname(stale_path))
+        File.write(stale_path, '<measure>stale, from a worker killed mid-ext')
+
+        job.send(:extract_archive, zip_path, dest)
+
+        expect(File.read(stale_path)).to eq('<measure>fresh</measure>'), 'overwrite defaults to true: stale pre-existing files must be replaced, not skipped'
+      end
+    end
+
+    it 'keeps a pre-existing file when overwrite is false' do
+      Dir.mktmpdir do |dir|
+        zip_path = build_measure_zip(File.join(dir, 'analysis.zip'), '<measure>fresh</measure>')
+        dest = File.join(dir, 'dest')
+        existing_path = File.join(dest, 'measures/m1/measure.xml')
+        FileUtils.mkdir_p(File.dirname(existing_path))
+        File.write(existing_path, '<measure>keep me</measure>')
+
+        job.send(:extract_archive, zip_path, dest, false)
+
+        expect(File.read(existing_path)).to eq('<measure>keep me</measure>')
+      end
+    end
+  end
+
   describe '#initialize_worker with a truncated analysis.zip download (issue #857 serving race)' do
     def build_valid_zip(path)
       Zip::OutputStream.open(path) do |zos|

--- a/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
+++ b/server/spec/models/dj_run_simulate_data_point_hardening_spec.rb
@@ -170,27 +170,33 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
       path
     end
 
-    it 'fails on the first extraction attempt (no retries), reports zip corruption, and cleans up the partial analysis_dir' do
+    it 'fails terminally after bounded validation attempts (no 12x retry), reports zip corruption, and cleans up the partial analysis_dir' do
       Dir.mktmpdir('corrupt-zip-fixture') do |fixture_dir|
         corrupt_zip = build_zlib_corrupt_zip(File.join(fixture_dir, 'analysis.zip'))
+        serve_count = 0
 
         job = build_job
         allow(job).to receive(:sleep) # skip the real stagger/backoff sleeps around the download step
         allow(URI).to receive(:open) do |*_args, &blk|
+          serve_count += 1
           File.open(corrupt_zip, 'rb', &blk)
         end
-        # This is the crux assertion: extraction must be attempted exactly once. If the
-        # fix regresses to the old 3x retry, this expectation raises immediately on the
-        # 2nd call (RSpec::Mocks::MockExpectationError), failing the example loudly.
-        expect(job).to receive(:extract_archive).once.and_call_original
+        # Since the issue #857 download-validation fix, deterministic corruption is
+        # caught BEFORE extraction: the downloaded bytes fail validation on
+        # 3 consecutive attempts (distinguishing corrupt-at-rest from a transiently
+        # truncated transfer, which heals on retry) and escalate to the same terminal
+        # CorruptAnalysisZip path. Extraction must never run against corrupt bytes,
+        # and the old blind 12x download retry must not resurrect.
+        expect(job).not_to receive(:extract_archive)
 
         analysis_dir = job.send(:analysis_dir)
         result = job.initialize_worker
 
         expect(result).to be false
+        expect(serve_count).to eq 3
         errs = job.instance_variable_get(:@intialize_worker_errs).join
         expect(errs).to match(/is corrupt and cannot be extracted/)
-        expect(errs).not_to match(/failed 3 times/)
+        expect(errs).not_to match(/Could not download the analysis zip after/)
         expect(Dir.exist?(analysis_dir)).to be false
       end
     end
@@ -220,6 +226,152 @@ RSpec.describe DjJobs::RunSimulateDataPoint, type: :model do
       expect(result).to be true
       expect(job.instance_variable_get(:@intialize_worker_errs)).to be_empty
       expect(job.instance_variable_get(:@data_point).analysis.initialize_worker_timeout).to eq 28800
+    end
+  end
+
+  # Regression specs for the analysis-zip corruption on shared-filesystem (NFS/k8s)
+  # deployments (issue #857). Three distinct defects, three seams:
+  #   1. extract_archive used the Zip::File.open block form with ::Zip.sort_entries = true;
+  #      the implicit close called commit, which REWRITES the archive in place (temp file +
+  #      rename) whenever sorting reordered the entry list. On the shared analysis dir that
+  #      rewrite races other workers downloading/extracting the same file.
+  #   2. The analysis.zip download wrote straight to its final shared path with no
+  #      integrity check, so a truncated/mid-rewrite fetch was extracted as-is and
+  #      escalated to a terminal CorruptAnalysisZip datapoint failure.
+  #   3. A worker that raced past the outer receipt check re-downloaded and re-extracted
+  #      the zip even when the receipt appeared before it acquired the lock, overwriting
+  #      content other datapoints were actively reading (the herd effect: N workers, N
+  #      serial re-downloads).
+  describe '#extract_archive read-only behavior (issue #857)' do
+    subject(:job) { described_class.allocate.tap { |j| j.instance_variable_set(:@sim_logger, Logger.new(nil)) } }
+
+    # Entries deliberately NOT in sorted order: that is what makes rubyzip's close
+    # decide commit_required? and rewrite the file when sort_entries is set.
+    def build_unsorted_zip(path)
+      Zip::OutputStream.open(path) do |zos|
+        zos.put_next_entry('zzz_last.txt')
+        zos.write('z' * 100)
+        zos.put_next_entry('aaa_first.txt')
+        zos.write('a' * 100)
+      end
+      path
+    end
+
+    it 'leaves the archive byte-identical after extraction' do
+      Dir.mktmpdir do |dir|
+        zip_path = build_unsorted_zip(File.join(dir, 'analysis.zip'))
+        before_md5 = Digest::MD5.file(zip_path).hexdigest
+        dest = File.join(dir, 'extract_dest')
+        FileUtils.mkdir_p(dest)
+
+        job.send(:extract_archive, zip_path, dest)
+
+        expect(Digest::MD5.file(zip_path).hexdigest).to eq(before_md5), 'extract_archive must never modify the archive it reads'
+        expect(File.read(File.join(dest, 'aaa_first.txt'))).to eq('a' * 100)
+        expect(File.read(File.join(dest, 'zzz_last.txt'))).to eq('z' * 100)
+      end
+    end
+  end
+
+  describe '#initialize_worker with a truncated analysis.zip download (issue #857 serving race)' do
+    def build_valid_zip(path)
+      Zip::OutputStream.open(path) do |zos|
+        zos.put_next_entry('measures/m1/measure.xml')
+        zos.write('<measure>deterministic payload</measure>' * 50)
+      end
+      path
+    end
+
+    it 'validates each fetch, retries truncated bytes, and only extracts verified bytes' do
+      Dir.mktmpdir('truncated-zip-fixture') do |fixture_dir|
+        valid_bytes = File.binread(build_valid_zip(File.join(fixture_dir, 'analysis.zip')))
+        truncated_bytes = valid_bytes[0...-30] # cuts the end-of-central-directory record
+        serve_count = 0
+
+        job = build_job
+        allow(job).to receive(:sleep) # skip the real stagger/backoff sleeps
+        allow(URI).to receive(:open) do |*_args, &blk|
+          serve_count += 1
+          blk.call(StringIO.new(serve_count < 3 ? truncated_bytes : valid_bytes))
+        end
+        fake_client = instance_double(OsHttp::Client)
+        allow(fake_client).to receive(:get).and_return(OsHttp::Response.new(200, '{}'))
+        allow(OsHttp).to receive(:client).and_return(fake_client)
+
+        result = job.initialize_worker
+
+        expect(result).to be(true), 'a transiently-truncated download must be retried, not escalated to a terminal corrupt-zip failure'
+        expect(serve_count).to be >= 3
+        download_file = File.join(job.send(:analysis_dir), 'analysis.zip')
+        expect(File.binread(download_file)).to eq(valid_bytes), 'only verified bytes may be placed at the shared analysis.zip path'
+        expect(File.exist?(File.join(job.send(:analysis_dir), 'analysis_zip.receipt'))).to be true
+      end
+    end
+  end
+
+  describe '#lock_abandoned? NFS-safe probe (issue #857 follow-up)' do
+    subject(:job) { described_class.allocate.tap { |j| j.instance_variable_set(:@sim_logger, Logger.new(nil)) } }
+
+    # Over NFSv4 flock is emulated with byte-range locks: an exclusive probe on a
+    # read-only fd raises Errno::EBADF (local filesystems allow it, which is why
+    # this never failed in CI). An unrescued EBADF crashes the waiter; rescuing it
+    # as "abandoned" is worse - it deletes a LIVE holder's lock, letting the next
+    # worker re-create the lock on a new inode and initialize the same analysis_dir
+    # concurrently. The only safe reading of an indeterminate probe is "held".
+    it 'returns false instead of raising when the flock probe fails with EBADF (NFSv4 read-only fd)' do
+      Dir.mktmpdir do |dir|
+        lock_path = File.join(dir, 'analysis_zip.lock')
+        File.write(lock_path, 'held by a live worker on another node')
+        allow_any_instance_of(File).to receive(:flock).and_raise(Errno::EBADF)
+
+        result = nil
+        expect { result = job.send(:lock_abandoned?, lock_path) }.not_to raise_error
+        expect(result).to be false
+      end
+    end
+
+    it 'does not report a held lock as abandoned' do
+      Dir.mktmpdir do |dir|
+        lock_path = File.join(dir, 'analysis_zip.lock')
+        holder = File.open(lock_path, 'a')
+        holder.flock(File::LOCK_EX)
+
+        expect(job.send(:lock_abandoned?, lock_path)).to be false
+      ensure
+        holder.flock(File::LOCK_UN)
+        holder.close
+      end
+    end
+
+    it 'reports an unheld lock file as abandoned' do
+      Dir.mktmpdir do |dir|
+        lock_path = File.join(dir, 'analysis_zip.lock')
+        File.write(lock_path, 'holder died without cleanup')
+
+        expect(job.send(:lock_abandoned?, lock_path)).to be true
+      end
+    end
+  end
+
+  describe '#initialize_worker receipt re-check inside the lock (issue #857 herd re-download)' do
+    it 'skips download/extract when the receipt appeared while queueing for the lock' do
+      job = build_job
+      receipt_file = File.join(job.send(:analysis_dir), 'analysis_zip.receipt')
+
+      # Deterministic reproduction of the race: this worker passed the outer receipt
+      # check (no receipt yet), and the init winner wrote the receipt just before this
+      # worker acquired the flock. and_wrap_original interposes at exactly that
+      # boundary; the real write_lock (real flock, real block) still runs.
+      allow(job).to receive(:write_lock).and_wrap_original do |orig, path, &blk|
+        File.write(receipt_file, 'winner finished while we queued for the lock')
+        orig.call(path, &blk)
+      end
+      expect(URI).not_to receive(:open)
+
+      result = job.initialize_worker
+
+      expect(result).to be true
+      expect(File.read(receipt_file)).to eq 'winner finished while we queued for the lock'
     end
   end
 end


### PR DESCRIPTION
## Summary

develop twin of #863 (which targets `179` / OS 3.10; develop = OS 3.11). Both branches will be maintained for a while, so the fix lands in both. Cherry-picked from `fix/zip-read-only-extract` minus the 179-only CI image-push commit.

Fixes #857. Closes #864. Closes #858.

## Zip corruption fix (#857)

Corruption chain found on the k8s/NFS cluster (flock exclusion itself works there):

1. `lock_abandoned?` probed `LOCK_EX` on a read-only fd — `Errno::EBADF` on NFSv4; the deployed EBADF→abandoned override then deleted **live** locks, letting a second worker initialize the same analysis_dir concurrently.
2. `extract_archive` (worker + `Analysis`) used the `Zip::File.open` block form with `::Zip.sort_entries = true` — implicit close commits, **rewriting the archive in place** for any unsorted zip (web-background rewrote the live seed zip while workers downloaded it).
3. Downloads wrote straight to the shared path unvalidated — truncated bytes extracted → terminal `CorruptAnalysisZip`.
4. Workers racing past the outer receipt check re-downloaded/re-extracted needlessly (observed 6 downloads in 3s).

Changes:
- `lock_abandoned?`: probe with `LOCK_SH` (grantable on read-only fds everywhere, still blocked by a live `LOCK_EX`); indeterminate = held, never abandoned.
- `extract_archive` (both copies): read-only `Zip::File.new`, no global `sort_entries` — archive byte-identical after extract.
- analysis.zip download: pid-suffixed temp → `Analysis.seed_zip_error` validation → atomic rename; 3 consecutive validation failures escalate to existing terminal cleanup (#841 preserved).
- Receipt re-check while holding the lock.

Regression specs written red-first against unfixed code; 36 examples green.

## overwrite fix (#858)

`extract_archive` (worker + `Analysis`) declared an `overwrite` parameter but never checked it — existing files were always skipped, so a worker killed mid-extract left stale `measure.xml` files the next worker kept. Now honored (default true); `overwrite=false` skip path pinned by spec. Red-first regression specs both copies.

## nginx fix (#864)

`docker/server/nginx.conf`: `keepalive_timeout 0` → `65`, `gzip off` → on (level 6, standard types, min 1000B). The 0/off values were copy-paste from the 2016 stock sample, not tuning. Matches the NatLabRockies/openstudio-server-helm c3c91ea ConfigMap override so that helm-side config fork (which hard-pins the passenger 6.0.27 path) can be dropped once images rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
